### PR TITLE
fix(config): Windows下配置写入文件锁不可用问题

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 
 	"gopkg.in/yaml.v3"
@@ -1021,18 +1020,6 @@ func IsPortAvailable(address string, port uint16) bool {
 	}
 	_ = ln.Close()
 	return true
-}
-
-// File locking helpers
-
-// lockFile acquires an exclusive lock on the file.
-func lockFile(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_EX)
-}
-
-// unlockFile releases the lock on the file.
-func unlockFile(f *os.File) error {
-	return syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
 }
 
 // writeFileWithLock writes data to a file with exclusive locking.

--- a/internal/config/filelock_unix.go
+++ b/internal/config/filelock_unix.go
@@ -1,0 +1,18 @@
+//go:build unix
+// +build unix
+
+package config
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_EX)
+}
+
+func unlockFile(f *os.File) error {
+	return unix.Flock(int(f.Fd()), unix.LOCK_UN)
+}

--- a/internal/config/filelock_windows.go
+++ b/internal/config/filelock_windows.go
@@ -1,0 +1,38 @@
+//go:build windows
+// +build windows
+
+package config
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockFile(f *os.File) error {
+	h := windows.Handle(f.Fd())
+	var ol windows.Overlapped
+
+	// Lock a huge region starting at offset 0 to effectively cover the whole file.
+	return windows.LockFileEx(
+		h,
+		windows.LOCKFILE_EXCLUSIVE_LOCK,
+		0,
+		0xFFFFFFFF,
+		0xFFFFFFFF,
+		&ol,
+	)
+}
+
+func unlockFile(f *os.File) error {
+	h := windows.Handle(f.Fd())
+	var ol windows.Overlapped
+
+	return windows.UnlockFileEx(
+		h,
+		0,
+		0xFFFFFFFF,
+		0xFFFFFFFF,
+		&ol,
+	)
+}


### PR DESCRIPTION
之前锁实现直接依赖 `syscall.Flock`，在 Windows 上不适用；本次改为按平台编译的锁实现：
- unix：`x/sys/unix.Flock`
- windows：`x/sys/windows.LockFileEx/UnlockFileEx`（独占锁）

`writeFileWithLock()` 调用方式与写入逻辑不变，只替换底层锁实现。