### PR TITLE
fix: support hysteria2 port hopping format for sing-box

### DIFF
--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -1121,14 +1121,14 @@ func normalizeHysteria2PortHoppingURI(rawURI string) (string, bool) {
 		return "", false
 	}
 	userInfo := rest[:atIdx]
-	hostPort := rest[atIdx+1:]
+	authority := rest[atIdx+1:]
 
-	portSep := strings.LastIndex(hostPort, ":")
+	portSep := strings.LastIndex(authority, ":")
 	if portSep == -1 {
 		return "", false
 	}
-	host := hostPort[:portSep]
-	rawPort := strings.TrimSpace(hostPort[portSep+1:])
+	host := authority[:portSep]
+	rawPort := strings.TrimSpace(authority[portSep+1:])
 	if host == "" || rawPort == "" {
 		return "", false
 	}

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -387,7 +387,14 @@ func buildPoolInbound(cfg *config.Config) (option.Inbound, error) {
 func buildNodeOutbound(tag, rawURI string, skipCertVerify bool) (option.Outbound, error) {
 	parsed, err := url.Parse(rawURI)
 	if err != nil {
-		return option.Outbound{}, fmt.Errorf("parse uri: %w", err)
+		normalizedURI, normalized := normalizeHysteria2PortHoppingURI(rawURI)
+		if !normalized {
+			return option.Outbound{}, fmt.Errorf("parse uri: %w", err)
+		}
+		parsed, err = url.Parse(normalizedURI)
+		if err != nil {
+			return option.Outbound{}, fmt.Errorf("parse uri: %w", err)
+		}
 	}
 	switch strings.ToLower(parsed.Scheme) {
 	case "vless":
@@ -497,14 +504,33 @@ func buildVLESSOptions(u *url.URL, skipCertVerify bool) (option.VLESSOutboundOpt
 
 func buildHysteria2Options(u *url.URL, skipCertVerify bool) (option.Hysteria2OutboundOptions, error) {
 	password := u.User.String()
-	server, port, err := hostPort(u, 443)
+	server, port, hopPorts, err := hysteria2HostPort(u, 443)
 	if err != nil {
 		return option.Hysteria2OutboundOptions{}, err
 	}
 	query := u.Query()
+	hopPorts = appendUniqueStrings(hopPorts, parseHysteria2Ports(query.Get("ports"))...)
+	hopPorts = appendUniqueStrings(hopPorts, parseHysteria2Ports(query.Get("server_ports"))...)
+	hopPorts = appendUniqueStrings(hopPorts, parseHysteria2Ports(query.Get("mport"))...)
 	opts := option.Hysteria2OutboundOptions{
 		ServerOptions: option.ServerOptions{Server: server, ServerPort: uint16(port)},
 		Password:      password,
+	}
+	if len(hopPorts) > 0 {
+		opts.ServerPorts = badoption.Listable[string](hopPorts)
+	}
+	if hopInterval := query.Get("hop_interval"); hopInterval != "" {
+		d, err := time.ParseDuration(hopInterval)
+		if err != nil {
+			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hop_interval %q", hopInterval)
+		}
+		opts.HopInterval = badoption.Duration(d)
+	} else if hopInterval := query.Get("hopInterval"); hopInterval != "" {
+		d, err := time.ParseDuration(hopInterval)
+		if err != nil {
+			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hopInterval %q", hopInterval)
+		}
+		opts.HopInterval = badoption.Duration(d)
 	}
 	if up := query.Get("upMbps"); up != "" {
 		opts.UpMbps = atoiDefault(up)
@@ -1062,6 +1088,154 @@ func hostPort(u *url.URL, defaultPort int) (string, int, error) {
 		return "", 0, fmt.Errorf("invalid port %q", portStr)
 	}
 	return host, port, nil
+}
+
+func normalizeHysteria2PortHoppingURI(rawURI string) (string, bool) {
+	lowerURI := strings.ToLower(rawURI)
+	if !strings.HasPrefix(lowerURI, "hysteria2://") && !strings.HasPrefix(lowerURI, "hy2://") {
+		return "", false
+	}
+
+	schemeSep := strings.Index(rawURI, "://")
+	if schemeSep == -1 {
+		return "", false
+	}
+
+	scheme := rawURI[:schemeSep]
+	rest := rawURI[schemeSep+3:]
+
+	fragment := ""
+	if idx := strings.Index(rest, "#"); idx != -1 {
+		fragment = rest[idx:]
+		rest = rest[:idx]
+	}
+
+	rawQuery := ""
+	if idx := strings.Index(rest, "?"); idx != -1 {
+		rawQuery = rest[idx+1:]
+		rest = rest[:idx]
+	}
+
+	atIdx := strings.LastIndex(rest, "@")
+	if atIdx == -1 {
+		return "", false
+	}
+	userInfo := rest[:atIdx]
+	hostPort := rest[atIdx+1:]
+
+	portSep := strings.LastIndex(hostPort, ":")
+	if portSep == -1 {
+		return "", false
+	}
+	host := hostPort[:portSep]
+	rawPort := strings.TrimSpace(hostPort[portSep+1:])
+	if host == "" || rawPort == "" {
+		return "", false
+	}
+
+	if _, err := strconv.Atoi(rawPort); err == nil {
+		return "", false
+	}
+	if !looksLikeHysteria2PortSet(rawPort) {
+		return "", false
+	}
+
+	values, err := url.ParseQuery(rawQuery)
+	if err != nil {
+		values = url.Values{}
+	}
+	if strings.TrimSpace(values.Get("ports")) == "" && strings.TrimSpace(values.Get("server_ports")) == "" && strings.TrimSpace(values.Get("mport")) == "" {
+		values.Set("ports", rawPort)
+	}
+
+	normalizedURI := fmt.Sprintf("%s://%s@%s:%d", scheme, userInfo, host, 443)
+	if encoded := values.Encode(); encoded != "" {
+		normalizedURI += "?" + encoded
+	}
+	normalizedURI += fragment
+
+	return normalizedURI, true
+}
+
+func looksLikeHysteria2PortSet(v string) bool {
+	if v == "" {
+		return false
+	}
+	for _, r := range v {
+		if (r >= '0' && r <= '9') || r == '-' || r == ',' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func hysteria2HostPort(u *url.URL, defaultPort int) (string, int, []string, error) {
+	host := u.Hostname()
+	if host == "" {
+		return "", 0, nil, errors.New("missing host")
+	}
+
+	port := defaultPort
+	var hopPorts []string
+	rawPort := strings.TrimSpace(u.Port())
+	if rawPort == "" {
+		return host, port, hopPorts, nil
+	}
+
+	if numericPort, err := strconv.Atoi(rawPort); err == nil {
+		return host, numericPort, hopPorts, nil
+	}
+
+	hopPorts = append(hopPorts, rawPort)
+	return host, port, hopPorts, nil
+}
+
+func parseHysteria2Ports(value string) []string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parts := strings.Split(value, ",")
+	ports := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part != "" {
+			ports = append(ports, normalizeHysteria2PortRange(part))
+		}
+	}
+	return ports
+}
+
+func normalizeHysteria2PortRange(portRange string) string {
+	if strings.Contains(portRange, ":") {
+		return portRange
+	}
+	if strings.Count(portRange, "-") == 1 {
+		return strings.Replace(portRange, "-", ":", 1)
+	}
+	return portRange
+}
+
+func appendUniqueStrings(base []string, values ...string) []string {
+	if len(values) == 0 {
+		return base
+	}
+	seen := make(map[string]struct{}, len(base))
+	for _, item := range base {
+		seen[item] = struct{}{}
+	}
+	for _, item := range values {
+		if item == "" {
+			continue
+		}
+		if _, ok := seen[item]; ok {
+			continue
+		}
+		seen[item] = struct{}{}
+		base = append(base, item)
+	}
+	return base
 }
 
 // normalizeShadowsocksMethod maps common Shadowsocks method aliases to the

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -522,13 +522,13 @@ func buildHysteria2Options(u *url.URL, skipCertVerify bool) (option.Hysteria2Out
 	if hopInterval := query.Get("hop_interval"); hopInterval != "" {
 		d, err := time.ParseDuration(hopInterval)
 		if err != nil {
-			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hop_interval %q", hopInterval)
+			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hop_interval %q: %w", hopInterval, err)
 		}
 		opts.HopInterval = badoption.Duration(d)
 	} else if hopInterval := query.Get("hopInterval"); hopInterval != "" {
 		d, err := time.ParseDuration(hopInterval)
 		if err != nil {
-			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hopInterval %q", hopInterval)
+			return option.Hysteria2OutboundOptions{}, fmt.Errorf("invalid hopInterval %q: %w", hopInterval, err)
 		}
 		opts.HopInterval = badoption.Duration(d)
 	}

--- a/internal/builder/builder_hysteria2_test.go
+++ b/internal/builder/builder_hysteria2_test.go
@@ -1,0 +1,49 @@
+package builder
+
+import (
+	"net/url"
+	"testing"
+
+	"github.com/sagernet/sing-box/option"
+)
+
+func TestBuildNodeOutbound_Hysteria2PortRangeInRawURI(t *testing.T) {
+	outbound, err := buildNodeOutbound("test-hy2", "hysteria2://secret@example.com:10000-20000?sni=hy2.example.com", false)
+	if err != nil {
+		t.Fatalf("build node outbound failed: %v", err)
+	}
+
+	opts, ok := outbound.Options.(*option.Hysteria2OutboundOptions)
+	if !ok {
+		t.Fatalf("expected *option.Hysteria2OutboundOptions, got %T", outbound.Options)
+	}
+
+	if opts.Server != "example.com" {
+		t.Fatalf("expected server example.com, got %q", opts.Server)
+	}
+	if opts.ServerPort != 443 {
+		t.Fatalf("expected default server port 443, got %d", opts.ServerPort)
+	}
+	if len(opts.ServerPorts) != 1 || opts.ServerPorts[0] != "10000:20000" {
+		t.Fatalf("expected server ports [10000:20000], got %v", opts.ServerPorts)
+	}
+}
+
+func TestBuildHysteria2Options_PortsFromQuery(t *testing.T) {
+	u, err := url.Parse("hysteria2://secret@example.com:443?ports=10000-20000,30000")
+	if err != nil {
+		t.Fatalf("parse uri failed: %v", err)
+	}
+
+	opts, err := buildHysteria2Options(u, false)
+	if err != nil {
+		t.Fatalf("build hysteria2 options failed: %v", err)
+	}
+
+	if len(opts.ServerPorts) != 2 {
+		t.Fatalf("expected 2 server ports, got %d (%v)", len(opts.ServerPorts), opts.ServerPorts)
+	}
+	if opts.ServerPorts[0] != "10000:20000" || opts.ServerPorts[1] != "30000" {
+		t.Fatalf("unexpected server ports: %v", opts.ServerPorts)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -31,7 +31,7 @@ type Config struct {
 	Nodes               []NodeConfig              `yaml:"nodes"`
 	NodesFile           string                    `yaml:"nodes_file"`    // 节点文件路径，每行一个 URI
 	Subscriptions       []string                  `yaml:"subscriptions"` // 订阅链接列表
-	ExternalIP          string                    `yaml:"external_ip"`      // 外部 IP 地址，用于导出时替换 0.0.0.0
+	ExternalIP          string                    `yaml:"external_ip"`   // 外部 IP 地址，用于导出时替换 0.0.0.0
 	LogLevel            string                    `yaml:"log_level"`
 	SkipCertVerify      bool                      `yaml:"skip_cert_verify"` // 全局跳过 SSL 证书验证
 
@@ -731,6 +731,7 @@ type clashProxy struct {
 	Type              string                 `yaml:"type"`
 	Server            string                 `yaml:"server"`
 	Port              int                    `yaml:"port"`
+	Ports             string                 `yaml:"ports"`
 	UUID              string                 `yaml:"uuid"`
 	Password          string                 `yaml:"password"`
 	Cipher            string                 `yaml:"cipher"`
@@ -746,12 +747,14 @@ type clashProxy struct {
 	GrpcOpts          *clashGrpcOptions      `yaml:"grpc-opts"`
 	RealityOpts       *clashRealityOptions   `yaml:"reality-opts"`
 	ClientFingerprint string                 `yaml:"client-fingerprint"`
+	Obfs              string                 `yaml:"obfs"`
+	ObfsPassword      string                 `yaml:"obfs-password"`
 	Plugin            string                 `yaml:"plugin"`
 	PluginOpts        map[string]interface{} `yaml:"plugin-opts"`
 	// TUIC-specific fields
-	ALPN                []string `yaml:"alpn"`
-	CongestionController string  `yaml:"congestion-controller"`
-	UDPRelayMode        string   `yaml:"udp-relay-mode"`
+	ALPN                 []string `yaml:"alpn"`
+	CongestionController string   `yaml:"congestion-controller"`
+	UDPRelayMode         string   `yaml:"udp-relay-mode"`
 }
 
 type clashWSOptions struct {
@@ -963,13 +966,54 @@ func buildHysteria2URI(p clashProxy) string {
 	if p.SkipCertVerify {
 		params.Set("insecure", "1")
 	}
+	if p.Obfs != "" {
+		params.Set("obfs", p.Obfs)
+		if p.ObfsPassword != "" {
+			params.Set("obfs-password", p.ObfsPassword)
+		}
+	}
+	if strings.TrimSpace(p.Ports) != "" {
+		params.Set("ports", normalizeHysteria2PortsValue(strings.TrimSpace(p.Ports)))
+	}
 
 	query := ""
 	if len(params) > 0 {
 		query = "?" + params.Encode()
 	}
 
-	return fmt.Sprintf("hysteria2://%s@%s:%d%s#%s", p.Password, p.Server, p.Port, query, url.QueryEscape(p.Name))
+	port := p.Port
+	if port <= 0 {
+		port = 443
+	}
+
+	return fmt.Sprintf("hysteria2://%s@%s:%d%s#%s", p.Password, p.Server, port, query, url.QueryEscape(p.Name))
+}
+
+func normalizeHysteria2PortsValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+
+	parts := strings.Split(value, ",")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if strings.Contains(part, ":") {
+			normalized = append(normalized, part)
+			continue
+		}
+		if strings.Count(part, "-") == 1 {
+			normalized = append(normalized, strings.Replace(part, "-", ":", 1))
+			continue
+		}
+		normalized = append(normalized, part)
+	}
+
+	return strings.Join(normalized, ",")
 }
 
 func buildTUICURI(p clashProxy) string {

--- a/internal/config/config_hysteria2_test.go
+++ b/internal/config/config_hysteria2_test.go
@@ -1,0 +1,56 @@
+package config
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestParseClashYAML_Hysteria2PortHoppingAndObfs(t *testing.T) {
+	content := `proxies:
+  - name: "test-hy2"
+    type: "hysteria2"
+    server: example.com
+    ports: 10000-20000
+    password: "secret"
+    obfs: "salamander"
+    obfs-password: "obfs-secret"
+    sni: "hy2.example.com"
+    skip-cert-verify: true
+`
+
+	nodes, err := parseClashYAML(content)
+	if err != nil {
+		t.Fatalf("parse clash yaml failed: %v", err)
+	}
+	if len(nodes) != 1 {
+		t.Fatalf("expected 1 node, got %d", len(nodes))
+	}
+
+	u, err := url.Parse(nodes[0].URI)
+	if err != nil {
+		t.Fatalf("parse generated uri failed: %v", err)
+	}
+	if u.Scheme != "hysteria2" {
+		t.Fatalf("expected scheme hysteria2, got %q", u.Scheme)
+	}
+	if u.Host != "example.com:443" {
+		t.Fatalf("expected host example.com:443, got %q", u.Host)
+	}
+
+	query := u.Query()
+	if query.Get("ports") != "10000:20000" {
+		t.Fatalf("expected ports=10000:20000, got %q", query.Get("ports"))
+	}
+	if query.Get("obfs") != "salamander" {
+		t.Fatalf("expected obfs=salamander, got %q", query.Get("obfs"))
+	}
+	if query.Get("obfs-password") != "obfs-secret" {
+		t.Fatalf("expected obfs-password=obfs-secret, got %q", query.Get("obfs-password"))
+	}
+	if query.Get("sni") != "hy2.example.com" {
+		t.Fatalf("expected sni=hy2.example.com, got %q", query.Get("sni"))
+	}
+	if query.Get("insecure") != "1" {
+		t.Fatalf("expected insecure=1, got %q", query.Get("insecure"))
+	}
+}


### PR DESCRIPTION
## Summary
- support Clash YAML hysteria2 fields: ports, obfs, obfs-password
- normalize hy2 port range from dash to colon for sing-box server_ports (for example 10000-20000 -> 10000:20000)
- keep raw hy2 URI port-hopping fallback and parse ports/server_ports/mport query values
- support hop_interval/hopInterval parsing

## Why
- sing-box accepts server port ranges in colon format. Dash format caused validation failures like: bad port range: 30000-50000.

## Validation
- go test ./internal/config ./internal/builder
- go test ./...
- local runtime check with config.yaml no longer shows bad port range errors

Closes #18