### PR TITLE
feat: zero-config docker deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,14 +9,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} go build -tags "with_utls with
 
 FROM debian:bookworm-slim AS runtime
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends ca-certificates gosu \
+    && apt-get install -y --no-install-recommends ca-certificates \
     && rm -rf /var/lib/apt/lists/* \
-    && useradd -r -u 10001 easy \
-    && mkdir -p /etc/easy_proxies \
-    && chown -R easy:easy /etc/easy_proxies
+    && mkdir -p /etc/easy_proxies /app
 WORKDIR /app
 COPY --from=builder /src/easy_proxies /usr/local/bin/easy_proxies
-COPY --chown=easy:easy config.example.yaml /etc/easy_proxies/config.yaml
+COPY config.example.yaml /app/config.example.yaml
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
 # Pool/Hybrid mode: 2323, Management: 9091, Multi-port/Hybrid mode: 24000-24200

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ Edit `config.yaml` and add your proxy nodes (inline nodes, `nodes.txt` file, or 
 
 ### 2. Run with Docker (Recommended)
 
+Zero-config: config files are auto-generated on first run.
+
+```bash
+mkdir -p data logs
+docker run --user $(id -u):$(id -g) \
+  -v $(pwd)/data:/etc/easy_proxies \
+  -v $(pwd)/logs:/app/logs \
+  --network host \
+  ghcr.io/jasonwong1991/easy_proxies:latest
+```
+
+Or use docker compose:
 ```bash
 ./start.sh
 # or manually:
@@ -314,7 +326,7 @@ When `management.password` is empty, authentication is bypassed.
 
 ### docker-compose.yml
 
-The default setup uses host networking (recommended for automatic port management). Volumes mount `config.yaml` and `nodes.txt`:
+The default setup uses host networking (recommended for automatic port management). Config directory is auto-generated on first run:
 
 ```yaml
 services:
@@ -323,16 +335,16 @@ services:
     container_name: easy_proxies
     restart: unless-stopped
     network_mode: host
+    user: "${UID:-10001}:${GID:-10001}"
     volumes:
-      - ./config.yaml:/etc/easy_proxies/config.yaml
-      - ./nodes.txt:/etc/easy_proxies/nodes.txt
+      - ./data:/etc/easy_proxies
       - ./logs:/app/logs
 ```
 
 ### Important Notes
 
-- **Create config files first**: `config.yaml` and `nodes.txt` must exist as files before running `docker compose up`. Use `./start.sh` which handles this automatically.
-- **Permissions**: Files need write permission for WebUI settings to persist (`chmod 666 config.yaml nodes.txt`).
+- **Zero-config**: When mapping a directory, `config.yaml` and `nodes.txt` are auto-generated on first run.
+- **Permissions**: Use `--user $(id -u):$(id -g)` to match your host user for file access.
 - **Multi-platform**: Supports amd64 and arm64 architectures.
 - **Reload**: `/api/reload` and subscription refresh will interrupt active connections.
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -13,7 +13,7 @@ services:
       - "2323:2323"       # Pool 入口
       - "9091:9091"       # WebUI
       - "24000-24100:24000-24100"  # Multi-port
+    user: "${UID:-10001}:${GID:-10001}"
     volumes:
-      - ./config.yaml:/etc/easy_proxies/config.yaml
-      - ./nodes.txt:/etc/easy_proxies/nodes.txt
+      - ./data:/etc/easy_proxies
       - ./logs:/app/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     restart: unless-stopped
     # 方式一：使用主机网络模式（推荐，支持端口自动重分配）
     network_mode: host
+    user: "${UID:-10001}:${GID:-10001}"
     # 方式二：手动映射端口（注释掉 network_mode，启用下面的 ports）
     # ports:
     #   # Pool 模式入口（pool/hybrid 模式使用）
@@ -24,15 +25,20 @@ services:
     #   - 独立节点入口：http://0.0.0.0:24000, ... 或 socks5://0.0.0.0:24000, ...（直连特定节点）
     #   - 节点状态在两种入口间共享（黑名单同步）
     #   - 端口冲突时自动重分配到下一个可用端口
-    # ⚠️ 重要：config.yaml 和 nodes.txt 必须在启动容器前创建为文件！
-    # 如果这些文件不存在，Docker 会将它们创建为目录，导致程序异常。
-    # 首次使用请先执行：
-    #   cp config.example.yaml config.yaml && touch nodes.txt
-    # 或直接使用 start.sh 启动（会自动处理）
+    #
+    # 使用示例：
+    #
+    #   方式一：映射配置目录（推荐，零配置启动）
+    #     docker run --user $(id -u):$(id -g) -v ./data:/etc/easy_proxies ghcr.io/jasonwong1991/easy_proxies:latest
+    #
+    #   方式二：映射配置文件（传统方式）
+    #     docker run -v ./config.yaml:/etc/easy_proxies/config.yaml -v ./nodes.txt:/etc/easy_proxies/nodes.txt ghcr.io/jasonwong1991/easy_proxies:latest
+    #
     volumes:
-      # 配置文件需要可写权限以支持 WebUI 设置保存
-      # 如遇权限问题，请在宿主机执行: chmod 666 config.yaml nodes.txt
-      - ./config.yaml:/etc/easy_proxies/config.yaml
-      - ./nodes.txt:/etc/easy_proxies/nodes.txt
+      # 方式一：映射配置目录（首次启动自动生成 config.yaml 和 nodes.txt）
+      - ./data:/etc/easy_proxies
+      # 方式二：映射配置文件（需要预先创建）
+      # - ./config.yaml:/etc/easy_proxies/config.yaml
+      # - ./nodes.txt:/etc/easy_proxies/nodes.txt
       # 日志映射目录（当从 WebUI 开启日志写到文件时有效）
       - ./logs:/app/logs

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,67 +1,28 @@
 #!/bin/sh
-# Fix bind-mount directory issue and ownership, then start easy_proxies
+# Auto-generate config and fix permissions, then start easy_proxies
 
-OVERRIDE_CONFIG=false
-CONFIG_PATH="/etc/easy_proxies/config.yaml"
+CONFIG_DIR="/etc/easy_proxies"
+CONFIG_FILE="$CONFIG_DIR/config.yaml"
+NODES_FILE="$CONFIG_DIR/nodes.txt"
+EXAMPLE_CONFIG="/app/config.example.yaml"
 
-# Check if config.yaml was bind-mounted as a directory (Docker creates directories
-# for non-existent bind-mount sources)
-if [ -d "/etc/easy_proxies/config.yaml" ]; then
-  echo "=======================================================" >&2
-  echo "WARNING: config.yaml is a directory, not a file!" >&2
-  echo "This happens when Docker creates the bind-mount target" >&2
-  echo "before the file exists on the host." >&2
-  echo "" >&2
-  echo "To fix permanently, run on the host:" >&2
-  echo "  docker compose down && rm -rf config.yaml && touch config.yaml && docker compose up -d" >&2
-  echo "Or use start.sh which handles this automatically." >&2
-  echo "=======================================================" >&2
+# Get current user uid/gid for permission fix
+CURRENT_UID=$(id -u 2>/dev/null || echo "10001")
+CURRENT_GID=$(id -g 2>/dev/null || echo "10001")
 
-  CONFIG_PATH="/tmp/default_config.yaml"
-  cat > "$CONFIG_PATH" <<'YAML'
-mode: pool
-
-listener:
-  address: 0.0.0.0
-  port: 2323
-
-pool:
-  mode: balance
-
-management:
-  enabled: true
-  listen: 0.0.0.0:9091
-  password: ""
-
-dns:
-  server: 223.5.5.5
-  port: 53
-  strategy: prefer_ipv4
-YAML
-  OVERRIDE_CONFIG=true
-  echo "INFO: Using fallback config at $CONFIG_PATH" >&2
+# Auto-generate config.yaml if not exists
+if [ ! -f "$CONFIG_FILE" ]; then
+    cp "$EXAMPLE_CONFIG" "$CONFIG_FILE"
+    echo "[easy_proxies] Generated default config from $EXAMPLE_CONFIG"
 fi
 
-# Check if nodes.txt was bind-mounted as a directory
-if [ -d "/etc/easy_proxies/nodes.txt" ]; then
-  echo "=======================================================" >&2
-  echo "WARNING: nodes.txt is a directory, not a file!" >&2
-  echo "This happens when Docker creates the bind-mount target" >&2
-  echo "before the file exists on the host." >&2
-  echo "" >&2
-  echo "To fix permanently, run on the host:" >&2
-  echo "  docker compose down && rm -rf nodes.txt && touch nodes.txt && docker compose up -d" >&2
-  echo "Or use start.sh which handles this automatically." >&2
-  echo "=======================================================" >&2
+# Auto-create nodes.txt if not exists
+if [ ! -f "$NODES_FILE" ]; then
+    touch "$NODES_FILE"
+    echo "[easy_proxies] Created empty nodes.txt"
 fi
 
-# Fix ownership of mounted config directory so the non-root user can write
-chown -R easy:easy /etc/easy_proxies 2>/dev/null || true
-chown -R easy:easy /app 2>/dev/null || true
+# Fix ownership of mounted files so the current user can access them
+chown -R "$CURRENT_UID:$CURRENT_GID" /etc/easy_proxies 2>/dev/null || true
 
-if [ "$OVERRIDE_CONFIG" = "true" ]; then
-  chown easy:easy "$CONFIG_PATH" 2>/dev/null || true
-  exec gosu easy /usr/local/bin/easy_proxies --config "$CONFIG_PATH"
-else
-  exec gosu easy /usr/local/bin/easy_proxies "$@"
-fi
+exec /usr/local/bin/easy_proxies "$@"

--- a/start.sh
+++ b/start.sh
@@ -1,38 +1,6 @@
 #!/bin/bash
-# Ensure config files exist as regular files before starting Docker containers.
-# Docker will create bind-mount targets as directories if they don't exist,
-# which breaks the application.
+# Ensure config directory exists and start easy_proxies
 
-# Fix config.yaml if it's a directory from a previous failed attempt
-if [ -d "config.yaml" ]; then
-  echo "WARNING: config.yaml is a directory (Docker bind-mount artifact). Removing and recreating as file..."
-  rm -rf config.yaml
-fi
-
-# Fix nodes.txt if it's a directory from a previous failed attempt
-if [ -d "nodes.txt" ]; then
-  echo "WARNING: nodes.txt is a directory (Docker bind-mount artifact). Removing and recreating as file..."
-  rm -rf nodes.txt
-fi
-
-# Create config.yaml if it doesn't exist
-if [ ! -f "config.yaml" ]; then
-  if [ -f "config.example.yaml" ]; then
-    echo "INFO: Creating config.yaml from config.example.yaml"
-    cp config.example.yaml config.yaml
-  else
-    echo "INFO: Creating empty config.yaml"
-    touch config.yaml
-  fi
-fi
-
-# Create nodes.txt if it doesn't exist
-if [ ! -f "nodes.txt" ]; then
-  echo "INFO: Creating empty nodes.txt"
-  touch nodes.txt
-fi
-
-# Ensure config files are writable for WebUI settings
-chmod 666 config.yaml nodes.txt 2>/dev/null || true
+mkdir -p data logs
 
 docker compose pull && docker compose down && docker compose up -d


### PR DESCRIPTION
close https://github.com/jasonwong1991/easy_proxies/issues/21

- Auto-generate config.yaml and nodes.txt from defaults on first run
- Remove hardcoded user in Dockerfile, use --user at runtime for permission control
- Add user: "${UID:-10001}:${GID:-10001}" in docker-compose.yml
- Simplify entrypoint.sh with auto-config generation and chown