### PR TITLE
支持 Shadowsocks 兼容链接格式

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ resp, err := client.Get("http://example.com")
 | VLESS | `vless://` | TCP, WS, HTTP/2, gRPC, HTTPUpgrade; TLS/Reality/uTLS |
 | VMess | `vmess://` | WS, HTTP/2, gRPC, HTTPUpgrade; TLS/uTLS |
 | Trojan | `trojan://` | WS, HTTP/2, gRPC, HTTPUpgrade; TLS/Reality/uTLS |
-| Shadowsocks | `ss://` | Direct; SIP002 format |
+| Shadowsocks | `ss://`, `shadowsocks://` | Direct; SIP002 and legacy whole-payload Base64 formats |
 | Hysteria2 | `hysteria2://`, `hy2://` | QUIC-based |
 | TUIC | `tuic://` | QUIC-based |
 | AnyTLS | `anytls://` | TLS |
@@ -278,6 +278,7 @@ resp, err := client.Get("http://example.com")
 ```yaml
 nodes:
   - uri: "vless://uuid@server:443?security=tls&type=ws&path=/path#Name"
+  - uri: "ss://base64(method:password@server:port)#Name"
 ```
 
 ### Nodes File

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -140,6 +140,8 @@ dns:
 - `vless`
 - `trojan`
 - `ss` / `shadowsocks`
+  - 支持 SIP002：`ss://base64(method:password)@server:port#name`
+  - 支持旧格式：`ss://base64(method:password@server:port)#name`
 - `hysteria2` / `hy2`
 - `socks5` / `socks`
 - `http` / `https`
@@ -254,4 +256,3 @@ go test ./...
 ## 许可证
 
 MIT License
-

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -167,6 +167,7 @@ nodes:
 # - Trojan:   trojan://password@server:port?params#name
 # - SS:       ss://method:password@server:port#name
 #             ss://base64(method:password)@server:port#name
+#             ss://base64(method:password@server:port)#name
 # - Hysteria2: hy2://password@server:port?params#name
 # - SOCKS5:  socks5://[user:pass@]server:port#name
 # - HTTP:    http://[user:pass@]server:port#name

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -16,6 +16,7 @@ import (
 	"easy_proxies/internal/config"
 	"easy_proxies/internal/geoip"
 	poolout "easy_proxies/internal/outbound/pool"
+	"easy_proxies/internal/ssuri"
 
 	C "github.com/sagernet/sing-box/constant"
 	"github.com/sagernet/sing-box/option"
@@ -459,6 +460,14 @@ func buildStickyInbound(cfg *config.Config) (option.Inbound, error) {
 }
 
 func buildNodeOutbound(tag, rawURI string, skipCertVerify bool) (option.Outbound, error) {
+	if isShadowsocksURI(rawURI) {
+		opts, err := buildShadowsocksOptions(rawURI)
+		if err != nil {
+			return option.Outbound{}, err
+		}
+		return option.Outbound{Type: C.TypeShadowsocks, Tag: tag, Options: &opts}, nil
+	}
+
 	parsed, err := url.Parse(rawURI)
 	if err != nil {
 		normalizedURI, normalized := normalizeHysteria2PortHoppingURI(rawURI)
@@ -483,12 +492,6 @@ func buildNodeOutbound(tag, rawURI string, skipCertVerify bool) (option.Outbound
 			return option.Outbound{}, err
 		}
 		return option.Outbound{Type: C.TypeHysteria2, Tag: tag, Options: &opts}, nil
-	case "ss", "shadowsocks":
-		opts, err := buildShadowsocksOptions(parsed)
-		if err != nil {
-			return option.Outbound{}, err
-		}
-		return option.Outbound{Type: C.TypeShadowsocks, Tag: tag, Options: &opts}, nil
 	case "trojan":
 		opts, err := buildTrojanOptions(parsed, skipCertVerify)
 		if err != nil {
@@ -754,38 +757,22 @@ func buildV2RayTransport(query url.Values) (*option.V2RayTransportOptions, error
 	return options, nil
 }
 
-func buildShadowsocksOptions(u *url.URL) (option.ShadowsocksOutboundOptions, error) {
-	server, port, err := hostPort(u, 8388)
+func buildShadowsocksOptions(rawURI string) (option.ShadowsocksOutboundOptions, error) {
+	parsed, err := ssuri.Parse(rawURI)
 	if err != nil {
 		return option.ShadowsocksOutboundOptions{}, err
 	}
 
-	// Decode userinfo (base64 encoded method:password)
-	userInfo := u.User.String()
-	decoded, err := base64.RawURLEncoding.DecodeString(userInfo)
-	if err != nil {
-		// Try standard base64
-		decoded, err = base64.StdEncoding.DecodeString(userInfo)
-		if err != nil {
-			return option.ShadowsocksOutboundOptions{}, fmt.Errorf("decode shadowsocks userinfo: %w", err)
-		}
-	}
-
-	parts := strings.SplitN(string(decoded), ":", 2)
-	if len(parts) != 2 {
-		return option.ShadowsocksOutboundOptions{}, errors.New("shadowsocks userinfo format must be method:password")
-	}
-
-	method := normalizeShadowsocksMethod(parts[0])
-	password := parts[1]
+	method := normalizeShadowsocksMethod(parsed.Method)
+	password := parsed.Password
 
 	opts := option.ShadowsocksOutboundOptions{
-		ServerOptions: option.ServerOptions{Server: server, ServerPort: uint16(port)},
+		ServerOptions: option.ServerOptions{Server: parsed.Server, ServerPort: uint16(parsed.Port)},
 		Method:        method,
 		Password:      password,
 	}
 
-	query := u.Query()
+	query := parsed.Query
 	if plugin := query.Get("plugin"); plugin != "" {
 		// sing-box library mode doesn't support external plugins like v2ray-plugin
 		// These require the plugin binary to be installed separately
@@ -793,6 +780,11 @@ func buildShadowsocksOptions(u *url.URL) (option.ShadowsocksOutboundOptions, err
 	}
 
 	return opts, nil
+}
+
+func isShadowsocksURI(rawURI string) bool {
+	lower := strings.ToLower(rawURI)
+	return strings.HasPrefix(lower, "ss://") || strings.HasPrefix(lower, "shadowsocks://")
 }
 
 func buildTrojanOptions(u *url.URL, skipCertVerify bool) (option.TrojanOutboundOptions, error) {

--- a/internal/builder/builder_shadowsocks_test.go
+++ b/internal/builder/builder_shadowsocks_test.go
@@ -1,0 +1,46 @@
+package builder
+
+import (
+	"strings"
+	"testing"
+
+	C "github.com/sagernet/sing-box/constant"
+	"github.com/sagernet/sing-box/option"
+)
+
+func TestBuildNodeOutbound_ShadowsocksLegacyWholePayloadBase64(t *testing.T) {
+	outbound, err := buildNodeOutbound("test-ss", "ss://YWVzLTI1Ni1nY206dGVzdC1wYXNzd29yZEBleGFtcGxlLmNvbTo4Mzg4#Synthetic-Node@example.net:8388", false)
+	if err != nil {
+		t.Fatalf("build node outbound failed: %v", err)
+	}
+
+	if outbound.Type != C.TypeShadowsocks {
+		t.Fatalf("expected type %q, got %q", C.TypeShadowsocks, outbound.Type)
+	}
+	opts, ok := outbound.Options.(*option.ShadowsocksOutboundOptions)
+	if !ok {
+		t.Fatalf("expected *option.ShadowsocksOutboundOptions, got %T", outbound.Options)
+	}
+	if opts.Method != "aes-256-gcm" {
+		t.Fatalf("expected method aes-256-gcm, got %q", opts.Method)
+	}
+	if opts.Password != "test-password" {
+		t.Fatalf("expected decoded password, got %q", opts.Password)
+	}
+	if opts.Server != "example.com" {
+		t.Fatalf("expected server example.com, got %q", opts.Server)
+	}
+	if opts.ServerPort != 8388 {
+		t.Fatalf("expected port 8388, got %d", opts.ServerPort)
+	}
+}
+
+func TestBuildNodeOutbound_ShadowsocksPluginStillUnsupported(t *testing.T) {
+	_, err := buildNodeOutbound("test-ss", "ss://aes-256-gcm:password@example.com:8388?plugin=v2ray-plugin", false)
+	if err == nil {
+		t.Fatalf("expected plugin error, got nil")
+	}
+	if !strings.Contains(err.Error(), "shadowsocks plugin not supported") {
+		t.Fatalf("expected plugin unsupported error, got %v", err)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -789,7 +789,7 @@ func isBase64(s string) bool {
 
 // IsProxyURI checks if a string is a valid proxy URI
 func IsProxyURI(s string) bool {
-	schemes := []string{"vmess://", "vless://", "trojan://", "ss://", "ssr://", "hysteria://", "hysteria2://", "hy2://", "tuic://", "socks5://", "socks5h://", "socks://", "http://", "https://", "anytls://"}
+	schemes := []string{"vmess://", "vless://", "trojan://", "ss://", "shadowsocks://", "ssr://", "hysteria://", "hysteria2://", "hy2://", "tuic://", "socks5://", "socks5h://", "socks://", "http://", "https://", "anytls://"}
 	lower := strings.ToLower(s)
 	for _, scheme := range schemes {
 		if strings.HasPrefix(lower, scheme) {

--- a/internal/config/shadowsocks_test.go
+++ b/internal/config/shadowsocks_test.go
@@ -1,0 +1,9 @@
+package config
+
+import "testing"
+
+func TestIsProxyURI_ShadowSocksLongScheme(t *testing.T) {
+	if !IsProxyURI("shadowsocks://aes-256-gcm:password@example.com:8388#Name") {
+		t.Fatalf("expected shadowsocks:// URI to be recognized")
+	}
+}

--- a/internal/geoip/geoip.go
+++ b/internal/geoip/geoip.go
@@ -2,9 +2,9 @@ package geoip
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
-	"context"
 	"fmt"
 	"io"
 	"log"
@@ -16,6 +16,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"easy_proxies/internal/ssuri"
 
 	"github.com/oschwald/geoip2-golang"
 )
@@ -498,8 +500,8 @@ func extractHostFromURI(uri string) string {
 		return extractVMessHost(uri)
 	}
 
-	// Shadowsocks: ss://base64(method:password)@host:port#name
-	if strings.HasPrefix(lowerURI, "ss://") {
+	// Shadowsocks: SIP002 and legacy whole-payload base64 formats.
+	if strings.HasPrefix(lowerURI, "ss://") || strings.HasPrefix(lowerURI, "shadowsocks://") {
 		return extractSSHost(uri)
 	}
 
@@ -580,25 +582,11 @@ func extractVMessHost(uri string) string {
 }
 
 func extractSSHost(uri string) string {
-	// Remove ss:// prefix
-	content := strings.TrimPrefix(uri, "ss://")
-
-	// Remove fragment (#name)
-	if idx := strings.Index(content, "#"); idx != -1 {
-		content = content[:idx]
+	parsed, err := ssuri.Parse(uri)
+	if err != nil {
+		return ""
 	}
-
-	// Check if it's the new format: base64@host:port
-	if atIdx := strings.LastIndex(content, "@"); atIdx != -1 {
-		hostPort := content[atIdx+1:]
-		if colonIdx := strings.LastIndex(hostPort, ":"); colonIdx != -1 {
-			return hostPort[:colonIdx]
-		}
-		return hostPort
-	}
-
-	// Old format: entire content is base64
-	return ""
+	return parsed.Server
 }
 
 func extractSSRHost(uri string) string {

--- a/internal/geoip/geoip_shadowsocks_test.go
+++ b/internal/geoip/geoip_shadowsocks_test.go
@@ -1,0 +1,24 @@
+package geoip
+
+import "testing"
+
+func TestExtractSSHost_LegacyWholePayloadBase64(t *testing.T) {
+	got := extractSSHost("ss://YWVzLTI1Ni1nY206dGVzdC1wYXNzd29yZEBleGFtcGxlLmNvbTo4Mzg4#Synthetic-Node@example.net:8388")
+	if got != "example.com" {
+		t.Fatalf("extractSSHost() = %q, want example.com", got)
+	}
+}
+
+func TestExtractSSHost_SIP002Base64(t *testing.T) {
+	got := extractSSHost("ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@example.com:8389#Test")
+	if got != "example.com" {
+		t.Fatalf("extractSSHost() = %q, want example.com", got)
+	}
+}
+
+func TestExtractHostFromURI_ShadowSocksLongScheme(t *testing.T) {
+	got := extractHostFromURI("shadowsocks://aes-256-gcm:password@example.com:8388#Test")
+	if got != "example.com" {
+		t.Fatalf("extractHostFromURI() = %q, want example.com", got)
+	}
+}

--- a/internal/ssuri/ssuri.go
+++ b/internal/ssuri/ssuri.go
@@ -1,0 +1,224 @@
+package ssuri
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const defaultPort = 8388
+
+// URI is the parsed form of a Shadowsocks URI.
+type URI struct {
+	Method   string
+	Password string
+	Server   string
+	Port     int
+	Query    url.Values
+	Fragment string
+}
+
+// Parse accepts SIP002 Shadowsocks URIs and the legacy whole-payload base64
+// format: ss://base64(method:password@host:port)#name.
+func Parse(raw string) (URI, error) {
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd < 0 {
+		return URI{}, errors.New("shadowsocks uri missing scheme")
+	}
+	scheme := strings.ToLower(raw[:schemeEnd])
+	if scheme != "ss" && scheme != "shadowsocks" {
+		return URI{}, fmt.Errorf("unsupported shadowsocks scheme %q", raw[:schemeEnd])
+	}
+
+	rest := raw[schemeEnd+3:]
+	fragment := ""
+	if hashIdx := strings.Index(rest, "#"); hashIdx >= 0 {
+		fragment, _ = url.PathUnescape(rest[hashIdx+1:])
+		rest = rest[:hashIdx]
+	}
+
+	query := url.Values{}
+	if queryIdx := strings.Index(rest, "?"); queryIdx >= 0 {
+		parsedQuery, err := url.ParseQuery(rest[queryIdx+1:])
+		if err != nil {
+			return URI{}, fmt.Errorf("parse shadowsocks query: %w", err)
+		}
+		query = parsedQuery
+		rest = rest[:queryIdx]
+	}
+	if rest == "" {
+		return URI{}, errors.New("shadowsocks uri missing payload")
+	}
+
+	if strings.Contains(rest, "@") {
+		return parseSIP002(rest, query, fragment)
+	}
+	return parseLegacy(rest, query, fragment)
+}
+
+func parseSIP002(rest string, query url.Values, fragment string) (URI, error) {
+	atIdx := strings.LastIndex(rest, "@")
+	if atIdx <= 0 || atIdx == len(rest)-1 {
+		return URI{}, errors.New("shadowsocks uri must include userinfo and host")
+	}
+
+	userInfo := rest[:atIdx]
+	hostPort := rest[atIdx+1:]
+	method, password, err := parseUserInfo(userInfo)
+	if err != nil {
+		return URI{}, err
+	}
+	server, port, err := parseHostPort(hostPort)
+	if err != nil {
+		return URI{}, err
+	}
+	return URI{Method: method, Password: password, Server: server, Port: port, Query: query, Fragment: fragment}, nil
+}
+
+func parseLegacy(encoded string, query url.Values, fragment string) (URI, error) {
+	decoded, err := decodeBase64(encoded)
+	if err != nil {
+		return URI{}, fmt.Errorf("decode legacy shadowsocks payload: %w", err)
+	}
+
+	decodedText := string(decoded)
+	atIdx := strings.LastIndex(decodedText, "@")
+	if atIdx <= 0 || atIdx == len(decodedText)-1 {
+		return URI{}, errors.New("legacy shadowsocks payload must be method:password@host:port")
+	}
+	methodPart := decodedText[:atIdx]
+	hostPort := decodedText[atIdx+1:]
+	method, password, err := parsePlainUserInfo(methodPart)
+	if err != nil {
+		return URI{}, err
+	}
+	server, port, err := parseHostPort(hostPort)
+	if err != nil {
+		return URI{}, err
+	}
+	return URI{Method: method, Password: password, Server: server, Port: port, Query: query, Fragment: fragment}, nil
+}
+
+func parseUserInfo(userInfo string) (string, string, error) {
+	if decoded, err := decodeBase64(userInfo); err == nil {
+		if method, password, plainErr := parsePlainUserInfo(string(decoded)); plainErr == nil {
+			return method, password, nil
+		}
+	}
+
+	unescaped, err := url.PathUnescape(userInfo)
+	if err != nil {
+		return "", "", fmt.Errorf("decode shadowsocks userinfo: %w", err)
+	}
+	return parsePlainUserInfo(unescaped)
+}
+
+func parsePlainUserInfo(userInfo string) (string, string, error) {
+	method, password, ok := strings.Cut(userInfo, ":")
+	if !ok {
+		return "", "", errors.New("shadowsocks userinfo format must be method:password")
+	}
+	if method == "" {
+		return "", "", errors.New("shadowsocks method is required")
+	}
+	if password == "" {
+		return "", "", errors.New("shadowsocks password is required")
+	}
+	return method, password, nil
+}
+
+func parseHostPort(hostPort string) (string, int, error) {
+	if hostPort == "" {
+		return "", 0, errors.New("shadowsocks host is required")
+	}
+
+	host := ""
+	port := defaultPort
+	if strings.HasPrefix(hostPort, "[") {
+		end := strings.Index(hostPort, "]")
+		if end < 0 {
+			return "", 0, errors.New("invalid IPv6 host")
+		}
+		host = hostPort[1:end]
+		remainder := hostPort[end+1:]
+		if remainder != "" {
+			if !strings.HasPrefix(remainder, ":") {
+				return "", 0, errors.New("invalid IPv6 host port")
+			}
+			parsedPort, err := parsePort(remainder[1:])
+			if err != nil {
+				return "", 0, err
+			}
+			port = parsedPort
+		}
+	} else if strings.Count(hostPort, ":") > 1 {
+		return "", 0, errors.New("IPv6 shadowsocks host must use [addr]:port")
+	} else if h, p, err := net.SplitHostPort(hostPort); err == nil {
+		host = h
+		parsedPort, err := parsePort(p)
+		if err != nil {
+			return "", 0, err
+		}
+		port = parsedPort
+	} else if strings.Contains(hostPort, ":") {
+		h, p, _ := strings.Cut(hostPort, ":")
+		host = h
+		parsedPort, err := parsePort(p)
+		if err != nil {
+			return "", 0, err
+		}
+		port = parsedPort
+	} else {
+		host = hostPort
+	}
+
+	if host == "" {
+		return "", 0, errors.New("shadowsocks host is required")
+	}
+	unescapedHost, err := url.PathUnescape(host)
+	if err != nil {
+		return "", 0, fmt.Errorf("decode shadowsocks host: %w", err)
+	}
+	return unescapedHost, port, nil
+}
+
+func parsePort(portText string) (int, error) {
+	if portText == "" {
+		return 0, errors.New("shadowsocks port is required")
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		return 0, fmt.Errorf("invalid shadowsocks port %q", portText)
+	}
+	if port <= 0 || port > 65535 {
+		return 0, fmt.Errorf("invalid shadowsocks port %q", portText)
+	}
+	return port, nil
+}
+
+func decodeBase64(s string) ([]byte, error) {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return nil, errors.New("empty base64 value")
+	}
+
+	encodings := []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	}
+	var lastErr error
+	for _, enc := range encodings {
+		decoded, err := enc.DecodeString(s)
+		if err == nil {
+			return decoded, nil
+		}
+		lastErr = err
+	}
+	return nil, lastErr
+}

--- a/internal/ssuri/ssuri_test.go
+++ b/internal/ssuri/ssuri_test.go
@@ -1,0 +1,139 @@
+package ssuri
+
+import "testing"
+
+func TestParseSupportedFormats(t *testing.T) {
+	tests := []struct {
+		name     string
+		raw      string
+		method   string
+		password string
+		server   string
+		port     int
+		fragment string
+	}{
+		{
+			name:     "legacy whole payload base64",
+			raw:      "ss://YWVzLTI1Ni1nY206dGVzdC1wYXNzd29yZEBleGFtcGxlLmNvbTo4Mzg4#Synthetic-Node@example.net:8388",
+			method:   "aes-256-gcm",
+			password: "test-password",
+			server:   "example.com",
+			port:     8388,
+			fragment: "Synthetic-Node@example.net:8388",
+		},
+		{
+			name:     "sip002 base64 userinfo",
+			raw:      "ss://YWVzLTI1Ni1nY206cGFzc3dvcmQ=@example.com:8389#Test",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "example.com",
+			port:     8389,
+			fragment: "Test",
+		},
+		{
+			name:     "plain userinfo",
+			raw:      "ss://aes-256-gcm:password@example.com:8388#Plain",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "example.com",
+			port:     8388,
+			fragment: "Plain",
+		},
+		{
+			name:     "url safe base64 without padding",
+			raw:      "ss://MjAyMi1ibGFrZTMtYWVzLTEyOC1nY206cC9hc3M_d29yZA@example.com:8443#URLSafe",
+			method:   "2022-blake3-aes-128-gcm",
+			password: "p/ass?word",
+			server:   "example.com",
+			port:     8443,
+			fragment: "URLSafe",
+		},
+		{
+			name:     "fragment containing at sign and port",
+			raw:      "ss://aes-256-gcm:password@example.com:9000#node@example.org:9000",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "example.com",
+			port:     9000,
+			fragment: "node@example.org:9000",
+		},
+		{
+			name:     "ipv6 host",
+			raw:      "ss://aes-256-gcm:password@[2001:db8::1]:8388#IPv6",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "2001:db8::1",
+			port:     8388,
+			fragment: "IPv6",
+		},
+		{
+			name:     "default port",
+			raw:      "ss://aes-256-gcm:password@example.com#DefaultPort",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "example.com",
+			port:     8388,
+			fragment: "DefaultPort",
+		},
+		{
+			name:     "shadowsocks scheme",
+			raw:      "shadowsocks://aes-256-gcm:password@example.com:8388#LongScheme",
+			method:   "aes-256-gcm",
+			password: "password",
+			server:   "example.com",
+			port:     8388,
+			fragment: "LongScheme",
+		},
+		{
+			name:     "legacy password containing at sign",
+			raw:      "ss://YWVzLTI1Ni1nY206cEBzc0BleGFtcGxlLmNvbTo4Mzg4#PasswordAt",
+			method:   "aes-256-gcm",
+			password: "p@ss",
+			server:   "example.com",
+			port:     8388,
+			fragment: "PasswordAt",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.raw)
+			if err != nil {
+				t.Fatalf("Parse() error = %v", err)
+			}
+			if got.Method != tt.method || got.Password != tt.password || got.Server != tt.server || got.Port != tt.port || got.Fragment != tt.fragment {
+				t.Fatalf("Parse() = %+v, want method=%q password=%q server=%q port=%d fragment=%q", got, tt.method, tt.password, tt.server, tt.port, tt.fragment)
+			}
+		})
+	}
+}
+
+func TestParseQuery(t *testing.T) {
+	got, err := Parse("ss://aes-256-gcm:password@example.com:8388?plugin=v2ray-plugin%3Btls#Query")
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if got.Query.Get("plugin") != "v2ray-plugin;tls" {
+		t.Fatalf("plugin query = %q", got.Query.Get("plugin"))
+	}
+}
+
+func TestParseInvalidURIs(t *testing.T) {
+	tests := []string{
+		"ss://@@@",
+		"ss://YWVzLTI1Ni1nY20tcGFzc3dvcmQ@example.com:8388",
+		"ss://:password@example.com:8388",
+		"ss://aes-256-gcm:@example.com:8388",
+		"ss://aes-256-gcm:password@example.com:notaport",
+		"ss://aes-256-gcm:password@[2001:db8::1:8388",
+		"ss://aes-256-gcm:password@2001:db8::1:8388",
+	}
+
+	for _, raw := range tests {
+		t.Run(raw, func(t *testing.T) {
+			if _, err := Parse(raw); err == nil {
+				t.Fatalf("Parse() error = nil, want error")
+			}
+		})
+	}
+}

--- a/nodes.example
+++ b/nodes.example
@@ -10,6 +10,8 @@ hysteria2://c5f7fbb5-2018-4295-8ff9-340d720c63c9@hinet-tw-01-ddns.sakuraikaede.c
 
 # Shadowsocks 协议示例
 ss://MjAyMi1ibGFrZTMtYWVzLTEyOC1nY206TWpBMFl6Z3daakJsTTJaa05tUmxOQT09OlpETmpNR1E0WkRjdE5qUmpOeTAwT0E9PQ@hkaws.go52pokemon.com:54259#🇹🇼台湾家宽节点
+# 旧式整段 Base64 Shadowsocks 格式也支持
+# ss://YWVzLTI1Ni1nY206dGVzdC1wYXNzd29yZEBleGFtcGxlLmNvbTo4Mzg4#测试旧格式节点
 
 # Trojan 协议示例
 trojan://d3c0d8d7-64c7-489c-8adb-e955615e7baa@sskr01.go52pokemon.com:59110?allowInsecure=1&peer=www.volcengine.com&sni=www.volcengine.com&type=tcp#🇰🇷韩国家宽节点


### PR DESCRIPTION
## 变更内容

- 新增 Shadowsocks URI 解析器，统一处理 SIP002、明文 userinfo、旧式整段 Base64 和 `shadowsocks://` 前缀。
- builder 使用共享解析器构建 Shadowsocks 出站，保留 plugin 不支持的现有限制。
- GeoIP 主机提取复用共享解析器，支持 legacy Base64 链接。
- 配置 URI 检测支持 `shadowsocks://`。
- README、中文文档和示例配置补充兼容格式说明。

## 验证

- 已新增 Shadowsocks 解析、builder、GeoIP 和 config 相关单元测试。
- 本 PR 创建前不额外运行测试。

Closes #27
