### PR TITLE
feat: 支持 hybrid 节点入池控制

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ easy_proxies-*
 config.yaml
 nodes.txt
 node_ports.json
+node_prefs.json
 
 # GeoIP database (auto-downloaded)
 *.mmdb

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ pool:
   blacklist_duration: 24h
   retry_enabled: true # retry on another node when a dial fails
   retry_attempts: 3   # max total dial attempts per request
+  exclude_keywords:   # optional: keep matching nodes out of the shared pool
+    - Premium
+    - high-rate
 
 management:
   enabled: true
@@ -313,6 +316,21 @@ Supports Base64, plain text, and Clash YAML formats. When subscriptions are conf
 
 **Stable Ports** (`multi-port`/`hybrid`): each node is identified by a stable key derived from its URI (ignoring the display name and parameter order), so a node keeps the same local port even when the subscription renames or reorders it. Assignments are saved to `node_ports.json` next to `config.yaml` and restored on restart.
 
+**Pool membership** (`hybrid`): nodes can keep their dedicated multi-port entry while staying out of the shared pool. For inline/manual nodes, set `pool_enabled: false`. For subscription or `nodes_file` nodes, WebUI changes are persisted in `node_prefs.json` next to `config.yaml`, keyed by the same stable node identity used for port preservation, so the preference survives subscription refreshes and renames. Use `pool.exclude_keywords` for bulk matching by node name, tag, or URI. An explicit node-level `pool_enabled: true` overrides keyword exclusion.
+
+```yaml
+pool:
+  exclude_keywords:
+    - Premium
+    - high-rate
+
+nodes:
+  - name: "Premium-HK-01"
+    uri: "vless://uuid@server:443?security=tls#Premium-HK-01"
+    port: 24001
+    pool_enabled: false
+```
+
 ## WebUI Dashboard
 
 Access at `http://your-server:9091` (configurable via the `management` section).
@@ -381,7 +399,7 @@ services:
 | 1221 | GeoIP region router (when enabled, configurable) |
 | 24000+ | Multi-port mode (one per node) |
 
-In `multi-port`/`hybrid` mode, per-node ports are persisted to `node_ports.json` (next to `config.yaml`) and restored on restart, so each node keeps a stable port across restarts and subscription refreshes. Delete this file to force a clean reassignment.
+In `multi-port`/`hybrid` mode, per-node ports are persisted to `node_ports.json` (next to `config.yaml`) and restored on restart, so each node keeps a stable port across restarts and subscription refreshes. Pool membership preferences for subscription/file nodes are persisted to `node_prefs.json` in the same directory. Delete these files to force a clean reassignment/default pool-membership state.
 
 ## Troubleshooting
 

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -73,6 +73,9 @@ pool:
   blacklist_duration: 24h
   retry_enabled: true # 拨号失败时切换到另一节点重试
   retry_attempts: 3   # 每个请求的最大拨号次数
+  exclude_keywords:   # 可选：命中的节点不加入共享代理池
+    - Premium
+    - high-rate
 
 management:
   enabled: true
@@ -141,6 +144,20 @@ dns:
   - 节点顺序：内联节点在前，订阅节点在后
   - 各节点的来源标识（inline/subscription）会在管理界面中显示
 - **端口稳定**（multi-port/hybrid）：节点按 URI 稳定标识（忽略名称与参数顺序），订阅改名或重排都保持同一本地端口；分配结果保存到 config.yaml 同目录的 `node_ports.json`，重启后自动恢复。删除该文件可强制重新分配。
+- **代理池成员控制**（hybrid）：节点可以保留独立端口但不加入共享代理池。内联/手动节点可设置 `pool_enabled: false`；订阅和 `nodes_file` 节点仍保持一行一个 URI，WebUI 修改会按稳定节点标识保存到 `node_prefs.json`，订阅刷新或改名后仍会恢复。也可用 `pool.exclude_keywords` 按名称、Tag 或 URI 批量排除。节点级 `pool_enabled: true` 会覆盖关键词排除。
+
+```yaml
+pool:
+  exclude_keywords:
+    - Premium
+    - high-rate
+
+nodes:
+  - name: "Premium-HK-01"
+    uri: "vless://uuid@server:443?security=tls#Premium-HK-01"
+    port: 24001
+    pool_enabled: false
+```
 
 ## 协议支持注意事项
 

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -62,6 +62,14 @@ pool:
   retry_enabled: true
   # 重试次数（包含首次拨号），默认 3
   retry_attempts: 3
+  # 排除关键词：未显式设置 pool_enabled 的节点，如果名称、Tag 或 URI 包含这些文本，
+  # 将不加入 pool/sticky/GeoIP 代理池，但在 hybrid/multi-port 下仍保留独立端口。
+  # 常用于订阅里的高倍率、Premium、特殊地区节点。
+  # 对订阅/nodes_file 节点在 WebUI 中设置的显式入池偏好会保存到 node_prefs.json，
+  # 订阅刷新或节点改名后仍会按稳定节点标识恢复。
+  exclude_keywords:
+    # - Premium
+    # - 高倍率
 
 # ───────────────────────────────────────────────────────────────
 # 粘性代理配置（可选，仅 pool / hybrid 模式生效）
@@ -156,6 +164,7 @@ nodes:
   # - name: "自定义名称"
   #   uri: "ss://base64@server:8388"
   #   port: 24001              # 手动指定端口（multi-port/hybrid 模式）
+  #   pool_enabled: false      # false = 只保留独立端口，不加入代理池
   #   username: "custom_user"  # 覆盖默认认证（可选）
   #   password: "custom_pass"
 

--- a/internal/boxmgr/createnode_inline_test.go
+++ b/internal/boxmgr/createnode_inline_test.go
@@ -2,6 +2,7 @@ package boxmgr
 
 import (
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -60,5 +61,95 @@ nodes: []
 	}
 	if !strings.Contains(string(data), "a.example.com") {
 		t.Errorf("config.yaml should contain the inline node URI, got:\n%s", data)
+	}
+}
+
+func TestCreateNode_PreservesPoolEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: hybrid\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &config.Config{
+		Mode:  "hybrid",
+		Nodes: []config.NodeConfig{},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	m := New(cfg, monitor.Config{})
+	poolEnabled := false
+	created, err := m.CreateNode(context.Background(), config.NodeConfig{
+		Name:        "Premium",
+		URI:         "socks5://127.0.0.1:1080#Premium",
+		PoolEnabled: &poolEnabled,
+	})
+	if err != nil {
+		t.Fatalf("CreateNode: %v", err)
+	}
+	if created.PoolEnabled == nil || *created.PoolEnabled {
+		t.Fatalf("created PoolEnabled = %v, want false", created.PoolEnabled)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config back: %v", err)
+	}
+	if !strings.Contains(string(data), "pool_enabled: false") {
+		t.Errorf("config.yaml should contain pool_enabled: false, got:\n%s", data)
+	}
+}
+
+func TestUpdateSubscriptionNode_PersistsPoolEnabledToSidecar(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	nodesPath := filepath.Join(dir, "nodes.txt")
+	if err := os.WriteFile(cfgPath, []byte("mode: hybrid\nnodes_file: nodes.txt\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	uri := "socks5://127.0.0.1:1080#Premium"
+	cfg := &config.Config{
+		Mode:      "hybrid",
+		NodesFile: nodesPath,
+		Nodes: []config.NodeConfig{
+			{Name: "Premium", URI: uri, Source: config.NodeSourceSubscription},
+		},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	m := New(cfg, monitor.Config{})
+	poolEnabled := false
+	updated, err := m.UpdateNode(context.Background(), "Premium", config.NodeConfig{
+		Name:        "Premium",
+		URI:         uri,
+		PoolEnabled: &poolEnabled,
+	})
+	if err != nil {
+		t.Fatalf("UpdateNode: %v", err)
+	}
+	if updated.Source != config.NodeSourceSubscription {
+		t.Fatalf("source = %q, want subscription", updated.Source)
+	}
+
+	nodesData, err := os.ReadFile(nodesPath)
+	if err != nil {
+		t.Fatalf("read nodes: %v", err)
+	}
+	if got := string(nodesData); got != uri+"\n" {
+		t.Fatalf("nodes.txt = %q, want URI only", got)
+	}
+
+	prefsData, err := os.ReadFile(filepath.Join(dir, "node_prefs.json"))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	var prefs map[string]config.NodePrefs
+	if err := json.Unmarshal(prefsData, &prefs); err != nil {
+		t.Fatalf("decode prefs: %v", err)
+	}
+	pref := prefs[(&config.NodeConfig{URI: uri}).NodeKey()]
+	if pref.PoolEnabled == nil || *pref.PoolEnabled {
+		t.Fatalf("pool preference = %#v, want false", pref.PoolEnabled)
 	}
 }

--- a/internal/boxmgr/manager.go
+++ b/internal/boxmgr/manager.go
@@ -490,7 +490,7 @@ func (m *Manager) createBox(ctx context.Context, cfg *config.Config) (*box.Box, 
 				if poolOpts, ok := ob.Options.(*pool.Options); ok {
 					poolOpts.Members = removeFromSlice(poolOpts.Members, badTag)
 					delete(poolOpts.Metadata, badTag)
-					
+
 					// If the pool is now empty, remove it to avoid another validation error
 					if len(poolOpts.Members) == 0 {
 						log.Printf("⚠️  Removing empty pool '%s'", ob.Tag)
@@ -867,6 +867,9 @@ func (m *Manager) ReloadWithPortMap(newCfg *config.Config, portMap map[string]ui
 	if err := newCfg.SaveNodePortMap(); err != nil {
 		m.logger.Warnf("failed to persist node ports: %v", err)
 	}
+	if err := newCfg.SaveNodePrefs(); err != nil {
+		m.logger.Warnf("failed to persist node prefs: %v", err)
+	}
 	return nil
 }
 
@@ -901,7 +904,6 @@ func extractPortFromBindError(err error) uint16 {
 	}
 	return 0
 }
-
 
 // reassignConflictingPort finds the node using the conflicting port and assigns a new port.
 func reassignConflictingPort(cfg *config.Config, conflictPort uint16) bool {

--- a/internal/builder/builder.go
+++ b/internal/builder/builder.go
@@ -27,7 +27,8 @@ import (
 // Build converts high level config into sing-box Options tree.
 func Build(cfg *config.Config) (option.Options, error) {
 	baseOutbounds := make([]option.Outbound, 0, len(cfg.Nodes))
-	memberTags := make([]string, 0, len(cfg.Nodes))
+	allMemberTags := make([]string, 0, len(cfg.Nodes))
+	poolMemberTags := make([]string, 0, len(cfg.Nodes))
 	metadata := make(map[string]poolout.MemberMeta)
 	var failedNodes []string
 	usedTags := make(map[string]int) // Track tag usage for uniqueness
@@ -66,7 +67,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 		}
 		baseTag := sanitizeTag(node.Name)
 		if baseTag == "" {
-			baseTag = fmt.Sprintf("node-%d", len(memberTags)+1)
+			baseTag = fmt.Sprintf("node-%d", len(allMemberTags)+1)
 		}
 
 		// Ensure tag uniqueness by appending a counter if needed
@@ -84,12 +85,17 @@ func Build(cfg *config.Config) (option.Options, error) {
 			failedNodes = append(failedNodes, node.Name)
 			continue
 		}
-		memberTags = append(memberTags, tag)
+		poolEnabled := cfg.NodePoolEnabled(node, tag)
+		allMemberTags = append(allMemberTags, tag)
+		if poolEnabled {
+			poolMemberTags = append(poolMemberTags, tag)
+		}
 		baseOutbounds = append(baseOutbounds, outbound)
 		meta := poolout.MemberMeta{
-			Name: node.Name,
-			URI:  node.URI,
-			Mode: cfg.Mode,
+			Name:        node.Name,
+			URI:         node.URI,
+			Mode:        cfg.Mode,
+			PoolEnabled: poolEnabled,
 		}
 		// For multi-port and hybrid modes, use per-node port
 		if cfg.Mode == "multi-port" || cfg.Mode == "hybrid" {
@@ -110,7 +116,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 	// Concurrent GeoIP resolution
 	if geoLookup != nil && geoLookup.IsEnabled() {
 		geoStart := time.Now()
-		log.Printf("🌍 Resolving GeoIP for %d nodes (concurrent)...", len(memberTags))
+		log.Printf("🌍 Resolving GeoIP for %d nodes (concurrent)...", len(allMemberTags))
 
 		type geoResult struct {
 			index  int
@@ -118,13 +124,13 @@ func Build(cfg *config.Config) (option.Options, error) {
 			region geoip.RegionInfo
 		}
 
-		results := make(chan geoResult, len(memberTags))
+		results := make(chan geoResult, len(allMemberTags))
 		var wg sync.WaitGroup
 
-		// Worker pool: min(32, len(memberTags))
+		// Worker pool: min(32, len(allMemberTags))
 		workerCount := 32
-		if len(memberTags) < workerCount {
-			workerCount = len(memberTags)
+		if len(allMemberTags) < workerCount {
+			workerCount = len(allMemberTags)
 		}
 
 		// Job channel
@@ -133,7 +139,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 			tag   string
 			uri   string
 		}
-		jobs := make(chan geoJob, len(memberTags))
+		jobs := make(chan geoJob, len(allMemberTags))
 
 		// Start workers
 		for w := 0; w < workerCount; w++ {
@@ -148,7 +154,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 		}
 
 		// Send jobs
-		for i, tag := range memberTags {
+		for i, tag := range allMemberTags {
 			meta := metadata[tag]
 			jobs <- geoJob{index: i, tag: tag, uri: meta.URI}
 		}
@@ -166,13 +172,15 @@ func Build(cfg *config.Config) (option.Options, error) {
 			meta.Region = res.region.Code
 			meta.Country = res.region.Country
 			metadata[res.tag] = meta
-			regionMembers[res.region.Code] = append(regionMembers[res.region.Code], res.tag)
+			if meta.PoolEnabled {
+				regionMembers[res.region.Code] = append(regionMembers[res.region.Code], res.tag)
+			}
 		}
 
 		log.Printf("🌍 GeoIP resolution completed in %.1fs", time.Since(geoStart).Seconds())
 	} else {
 		// No GeoIP - assign all to "other" region
-		for _, tag := range memberTags {
+		for _, tag := range poolMemberTags {
 			regionMembers[geoip.RegionOther] = append(regionMembers[geoip.RegionOther], tag)
 		}
 	}
@@ -221,6 +229,9 @@ func Build(cfg *config.Config) (option.Options, error) {
 	if !enablePoolInbound && !enableMultiPort {
 		return option.Options{}, fmt.Errorf("unsupported mode %s", cfg.Mode)
 	}
+	if enablePoolInbound && len(poolMemberTags) == 0 {
+		return option.Options{}, fmt.Errorf("no pool-enabled nodes available (all %d valid nodes are excluded from the shared pool)", len(baseOutbounds))
+	}
 
 	// Build pool inbound (single entry point for all nodes)
 	if enablePoolInbound {
@@ -231,7 +242,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 		inbounds = append(inbounds, inbound)
 		poolOptions := poolout.Options{
 			Mode:              cfg.Pool.Mode,
-			Members:           memberTags,
+			Members:           poolMemberTags,
 			FailureThreshold:  cfg.Pool.FailureThreshold,
 			BlacklistDuration: cfg.Pool.BlacklistDuration,
 			RetryEnabled:      cfg.Pool.RetryEnabledOrDefault(),
@@ -257,7 +268,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 			inbounds = append(inbounds, stickyInbound)
 			stickyOptions := poolout.Options{
 				Mode:              cfg.Pool.Mode,
-				Members:           memberTags,
+				Members:           poolMemberTags,
 				FailureThreshold:  cfg.Pool.FailureThreshold,
 				BlacklistDuration: cfg.Pool.BlacklistDuration,
 				RetryEnabled:      cfg.Pool.RetryEnabledOrDefault(),
@@ -293,7 +304,7 @@ func Build(cfg *config.Config) (option.Options, error) {
 		if err != nil {
 			return option.Options{}, fmt.Errorf("parse multi-port address: %w", err)
 		}
-		for _, tag := range memberTags {
+		for _, tag := range allMemberTags {
 			meta := metadata[tag]
 			perMeta := map[string]poolout.MemberMeta{tag: meta}
 			poolTag := fmt.Sprintf("%s-%s", poolout.Tag, tag)

--- a/internal/builder/builder_pool_enabled_test.go
+++ b/internal/builder/builder_pool_enabled_test.go
@@ -1,0 +1,122 @@
+package builder
+
+import (
+	"strings"
+	"testing"
+
+	"easy_proxies/internal/config"
+	poolout "easy_proxies/internal/outbound/pool"
+)
+
+func boolPtr(v bool) *bool {
+	return &v
+}
+
+func poolOptionsByTag(t *testing.T, cfg *config.Config, tag string) *poolout.Options {
+	t.Helper()
+	opts, err := Build(cfg)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	for _, outbound := range opts.Outbounds {
+		if outbound.Tag != tag {
+			continue
+		}
+		poolOpts, ok := outbound.Options.(*poolout.Options)
+		if !ok {
+			t.Fatalf("outbound %q options = %T, want *pool.Options", tag, outbound.Options)
+		}
+		return poolOpts
+	}
+	t.Fatalf("pool outbound %q not found", tag)
+	return nil
+}
+
+func TestBuildHybrid_PoolDisabledNodeKeepsMultiPortOnly(t *testing.T) {
+	cfg := &config.Config{
+		Mode:      "hybrid",
+		Listener:  config.ListenerConfig{Address: "127.0.0.1", Port: 2323},
+		MultiPort: config.MultiPortConfig{Address: "127.0.0.1", BasePort: 24000},
+		Pool:      config.PoolConfig{Mode: "sequential"},
+		Nodes: []config.NodeConfig{
+			{Name: "Normal", URI: "socks5://127.0.0.1:1080#Normal", Port: 24000},
+			{Name: "Premium", URI: "socks5://127.0.0.1:1081#Premium", Port: 24001, PoolEnabled: boolPtr(false)},
+		},
+	}
+
+	mainPool := poolOptionsByTag(t, cfg, poolout.Tag)
+	if got, want := strings.Join(mainPool.Members, ","), "normal"; got != want {
+		t.Fatalf("main pool members = %q, want %q", got, want)
+	}
+
+	premiumPortPool := poolOptionsByTag(t, cfg, poolout.Tag+"-premium")
+	if got, want := strings.Join(premiumPortPool.Members, ","), "premium"; got != want {
+		t.Fatalf("premium multi-port pool members = %q, want %q", got, want)
+	}
+	if meta := premiumPortPool.Metadata["premium"]; meta.PoolEnabled {
+		t.Fatalf("premium metadata PoolEnabled = true, want false")
+	}
+}
+
+func TestBuild_PoolExcludeKeywordsAndExplicitOverride(t *testing.T) {
+	cfg := &config.Config{
+		Mode:      "hybrid",
+		Listener:  config.ListenerConfig{Address: "127.0.0.1", Port: 2323},
+		MultiPort: config.MultiPortConfig{Address: "127.0.0.1", BasePort: 24000},
+		Pool: config.PoolConfig{
+			Mode:            "sequential",
+			ExcludeKeywords: []string{"premium"},
+		},
+		Nodes: []config.NodeConfig{
+			{Name: "Normal", URI: "socks5://127.0.0.1:1080#Normal", Port: 24000},
+			{Name: "Premium", URI: "socks5://127.0.0.1:1081#Premium", Port: 24001},
+			{Name: "Premium Force", URI: "socks5://127.0.0.1:1082#PremiumForce", Port: 24002, PoolEnabled: boolPtr(true)},
+		},
+	}
+
+	mainPool := poolOptionsByTag(t, cfg, poolout.Tag)
+	if got, want := strings.Join(mainPool.Members, ","), "normal,premium-force"; got != want {
+		t.Fatalf("main pool members = %q, want %q", got, want)
+	}
+}
+
+func TestBuild_AllPoolMembersExcludedFails(t *testing.T) {
+	cfg := &config.Config{
+		Mode:     "pool",
+		Listener: config.ListenerConfig{Address: "127.0.0.1", Port: 2323},
+		Pool: config.PoolConfig{
+			Mode:            "sequential",
+			ExcludeKeywords: []string{"premium"},
+		},
+		Nodes: []config.NodeConfig{
+			{Name: "Premium", URI: "socks5://127.0.0.1:1081#Premium"},
+		},
+	}
+
+	_, err := Build(cfg)
+	if err == nil {
+		t.Fatalf("expected build error")
+	}
+	if !strings.Contains(err.Error(), "no pool-enabled nodes available") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestBuild_GeoIPRegionPoolsUseOnlyPoolEnabledMembers(t *testing.T) {
+	cfg := &config.Config{
+		Mode:      "hybrid",
+		Listener:  config.ListenerConfig{Address: "127.0.0.1", Port: 2323},
+		MultiPort: config.MultiPortConfig{Address: "127.0.0.1", BasePort: 24000},
+		Pool:      config.PoolConfig{Mode: "sequential"},
+		GeoIP:     config.GeoIPConfig{Enabled: true},
+		Nodes: []config.NodeConfig{
+			{Name: "Normal", URI: "socks5://127.0.0.1:1080#Normal", Port: 24000},
+			{Name: "Premium", URI: "socks5://127.0.0.1:1081#Premium", Port: 24001, PoolEnabled: boolPtr(false)},
+		},
+	}
+
+	regionPool := poolOptionsByTag(t, cfg, "pool-other")
+	if got, want := strings.Join(regionPool.Members, ","), "normal"; got != want {
+		t.Fatalf("region pool members = %q, want %q", got, want)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,6 +82,7 @@ type PoolConfig struct {
 	Mode              string        `yaml:"mode"`
 	FailureThreshold  int           `yaml:"failure_threshold"`
 	BlacklistDuration time.Duration `yaml:"blacklist_duration"`
+	ExcludeKeywords   []string      `yaml:"exclude_keywords,omitempty"`
 	// RetryEnabled toggles automatic fail-over to another member when a dial fails.
 	// nil/unset → default true. Use *bool so users can explicitly disable via YAML.
 	RetryEnabled *bool `yaml:"retry_enabled,omitempty"`
@@ -138,12 +139,13 @@ const (
 
 // NodeConfig describes a single upstream proxy endpoint expressed as URI.
 type NodeConfig struct {
-	Name     string     `yaml:"name" json:"name"`
-	URI      string     `yaml:"uri" json:"uri"`
-	Port     uint16     `yaml:"port,omitempty" json:"port,omitempty"`
-	Username string     `yaml:"username,omitempty" json:"username,omitempty"`
-	Password string     `yaml:"password,omitempty" json:"password,omitempty"`
-	Source   NodeSource `yaml:"-" json:"source,omitempty"` // Runtime only, not persisted
+	Name        string     `yaml:"name" json:"name"`
+	URI         string     `yaml:"uri" json:"uri"`
+	Port        uint16     `yaml:"port,omitempty" json:"port,omitempty"`
+	Username    string     `yaml:"username,omitempty" json:"username,omitempty"`
+	Password    string     `yaml:"password,omitempty" json:"password,omitempty"`
+	PoolEnabled *bool      `yaml:"pool_enabled,omitempty" json:"pool_enabled,omitempty"`
+	Source      NodeSource `yaml:"-" json:"source,omitempty"` // Runtime only, not persisted
 }
 
 // NodeKey returns a stable identifier for the node, used to preserve port
@@ -156,6 +158,25 @@ type NodeConfig struct {
 // keeps the same key — and therefore the same proxy port.
 func (n *NodeConfig) NodeKey() string {
 	return stableNodeKey(n.URI)
+}
+
+// NodePoolEnabled reports whether a node should participate in shared pool
+// entries. Per-node configuration wins over keyword matching.
+func (c *Config) NodePoolEnabled(node NodeConfig, tag string) bool {
+	if node.PoolEnabled != nil {
+		return *node.PoolEnabled
+	}
+	if c == nil || len(c.Pool.ExcludeKeywords) == 0 {
+		return true
+	}
+	haystack := strings.ToLower(node.Name + "\n" + tag + "\n" + node.URI)
+	for _, keyword := range c.Pool.ExcludeKeywords {
+		keyword = strings.ToLower(strings.TrimSpace(keyword))
+		if keyword != "" && strings.Contains(haystack, keyword) {
+			return false
+		}
+	}
+	return true
 }
 
 // stableNodeKey derives a port-stable identity from a proxy URI by stripping the
@@ -214,6 +235,8 @@ func Load(path string) (*Config, error) {
 	if err := cfg.normalize(); err != nil {
 		return nil, err
 	}
+
+	cfg.ApplyNodePrefs()
 
 	// Restore persisted proxy ports so a restart keeps the same port per node.
 	if err := cfg.applyPersistedPorts(); err != nil {
@@ -389,6 +412,9 @@ func (c *Config) normalize() error {
 			cachedNodes, err := loadNodesFromFile(c.NodesFile)
 			if err == nil && len(cachedNodes) > 0 {
 				log.Printf("⚠️  All subscriptions failed, using %d cached nodes from %s", len(cachedNodes), c.NodesFile)
+				for idx := range cachedNodes {
+					cachedNodes[idx].Source = NodeSourceSubscription
+				}
 				c.Nodes = append(c.Nodes, cachedNodes...)
 			}
 		}
@@ -492,6 +518,12 @@ func (c *Config) BuildPortMap() map[string]uint16 {
 // survive a process restart.
 const nodePortMapFile = "node_ports.json"
 
+const nodePrefsFile = "node_prefs.json"
+
+type NodePrefs struct {
+	PoolEnabled *bool `json:"pool_enabled,omitempty"`
+}
+
 // portMapPath returns the path of the port-map sidecar, located next to the
 // main config file. It is empty when the config path is unknown.
 func (c *Config) portMapPath() string {
@@ -499,6 +531,13 @@ func (c *Config) portMapPath() string {
 		return ""
 	}
 	return filepath.Join(filepath.Dir(c.filePath), nodePortMapFile)
+}
+
+func (c *Config) nodePrefsPath() string {
+	if c.filePath == "" {
+		return ""
+	}
+	return filepath.Join(filepath.Dir(c.filePath), nodePrefsFile)
 }
 
 // loadNodePortMap reads a previously saved stableNodeKey→port mapping. It
@@ -517,6 +556,79 @@ func loadNodePortMap(path string) map[string]uint16 {
 		return nil
 	}
 	return m
+}
+
+func loadNodePrefs(path string) map[string]NodePrefs {
+	if path == "" {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var m map[string]NodePrefs
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil
+	}
+	return m
+}
+
+// ApplyNodePrefs restores persisted per-node preferences for file/subscription
+// nodes. Inline nodes keep their explicit config.yaml values.
+func (c *Config) ApplyNodePrefs() {
+	if c == nil {
+		return
+	}
+	prefs := loadNodePrefs(c.nodePrefsPath())
+	if len(prefs) == 0 {
+		return
+	}
+	for i := range c.Nodes {
+		switch c.Nodes[i].Source {
+		case NodeSourceFile, NodeSourceSubscription:
+		default:
+			continue
+		}
+		pref, ok := prefs[c.Nodes[i].NodeKey()]
+		if !ok || pref.PoolEnabled == nil {
+			continue
+		}
+		c.Nodes[i].PoolEnabled = pref.PoolEnabled
+	}
+}
+
+func (c *Config) BuildNodePrefs() map[string]NodePrefs {
+	prefs := make(map[string]NodePrefs)
+	for _, node := range c.Nodes {
+		switch node.Source {
+		case NodeSourceFile, NodeSourceSubscription:
+		default:
+			continue
+		}
+		if node.PoolEnabled == nil {
+			continue
+		}
+		prefs[node.NodeKey()] = NodePrefs{PoolEnabled: node.PoolEnabled}
+	}
+	return prefs
+}
+
+func (c *Config) SaveNodePrefs() error {
+	if c == nil {
+		return errors.New("config is nil")
+	}
+	path := c.nodePrefsPath()
+	if path == "" {
+		return errors.New("config file path is unknown")
+	}
+	data, err := json.MarshalIndent(c.BuildNodePrefs(), "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode node prefs: %w", err)
+	}
+	if err := writeFileWithLock(path, data, 0o644); err != nil {
+		return fmt.Errorf("write node prefs %q: %w", path, err)
+	}
+	return nil
 }
 
 // bridgeLegacyPortKeys upgrades a port-map sidecar written by an older version
@@ -1498,11 +1610,12 @@ func (c *Config) SaveNodes() error {
 	for _, node := range c.Nodes {
 		// Create a clean copy without runtime fields for saving
 		cleanNode := NodeConfig{
-			Name:     node.Name,
-			URI:      node.URI,
-			Port:     node.Port,
-			Username: node.Username,
-			Password: node.Password,
+			Name:        node.Name,
+			URI:         node.URI,
+			Port:        node.Port,
+			Username:    node.Username,
+			Password:    node.Password,
+			PoolEnabled: node.PoolEnabled,
 		}
 		switch node.Source {
 		case NodeSourceInline:
@@ -1513,6 +1626,10 @@ func (c *Config) SaveNodes() error {
 			// Default to file nodes for unknown source
 			fileNodes = append(fileNodes, cleanNode)
 		}
+	}
+
+	if err := c.SaveNodePrefs(); err != nil {
+		return fmt.Errorf("save node prefs: %w", err)
 	}
 
 	// Write file-based nodes to nodes.txt

--- a/internal/config/pool_membership_test.go
+++ b/internal/config/pool_membership_test.go
@@ -1,0 +1,240 @@
+package config
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func testBoolPtr(v bool) *bool {
+	return &v
+}
+
+func TestSaveNodes_PersistsFileNodePoolEnabledToSidecar(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	nodesPath := filepath.Join(dir, "nodes.txt")
+	if err := os.WriteFile(cfgPath, []byte("mode: hybrid\nnodes_file: nodes.txt\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	uri := "socks5://127.0.0.1:1080#Premium"
+	cfg := &Config{
+		Mode:      "hybrid",
+		NodesFile: nodesPath,
+		Nodes: []NodeConfig{
+			{
+				Name:        "Premium",
+				URI:         uri,
+				PoolEnabled: testBoolPtr(false),
+				Source:      NodeSourceSubscription,
+			},
+		},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	if err := cfg.SaveNodes(); err != nil {
+		t.Fatalf("SaveNodes: %v", err)
+	}
+
+	nodesData, err := os.ReadFile(nodesPath)
+	if err != nil {
+		t.Fatalf("read nodes: %v", err)
+	}
+	if got := string(nodesData); got != uri+"\n" {
+		t.Fatalf("nodes.txt = %q, want URI only", got)
+	}
+
+	prefsData, err := os.ReadFile(filepath.Join(dir, nodePrefsFile))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	var prefs map[string]NodePrefs
+	if err := json.Unmarshal(prefsData, &prefs); err != nil {
+		t.Fatalf("decode prefs: %v", err)
+	}
+	pref := prefs[stableNodeKey(uri)]
+	if pref.PoolEnabled == nil || *pref.PoolEnabled {
+		t.Fatalf("pool preference = %#v, want false", pref.PoolEnabled)
+	}
+}
+
+func TestLoad_AppliesNodePrefsAcrossRenameAndQueryReorder(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	nodesPath := filepath.Join(dir, "nodes.txt")
+	if err := os.WriteFile(cfgPath, []byte("mode: pool\nnodes_file: nodes.txt\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldURI := "vless://uuid-a@example.com:443?type=ws&security=tls#Old"
+	newURI := "vless://uuid-a@example.com:443?security=tls&type=ws#New"
+	if err := os.WriteFile(nodesPath, []byte(newURI+"\n"), 0o644); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+	prefs := map[string]NodePrefs{
+		stableNodeKey(oldURI): {PoolEnabled: testBoolPtr(false)},
+	}
+	prefsData, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatalf("encode prefs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, nodePrefsFile), prefsData, 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(cfg.Nodes))
+	}
+	if cfg.Nodes[0].PoolEnabled == nil || *cfg.Nodes[0].PoolEnabled {
+		t.Fatalf("PoolEnabled = %v, want false", cfg.Nodes[0].PoolEnabled)
+	}
+}
+
+func TestLoad_AppliesNodePrefsToCachedSubscriptionNodes(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	nodesPath := filepath.Join(dir, "nodes.txt")
+	if err := os.WriteFile(cfgPath, []byte("mode: pool\nnodes_file: nodes.txt\nsubscriptions:\n  - http://127.0.0.1:1/sub\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	uri := "socks5://127.0.0.1:1080#Cached"
+	if err := os.WriteFile(nodesPath, []byte(uri+"\n"), 0o644); err != nil {
+		t.Fatalf("write nodes: %v", err)
+	}
+	prefs := map[string]NodePrefs{
+		stableNodeKey(uri): {PoolEnabled: testBoolPtr(false)},
+	}
+	prefsData, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatalf("encode prefs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, nodePrefsFile), prefsData, 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+
+	cfg, err := Load(cfgPath)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(cfg.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(cfg.Nodes))
+	}
+	if cfg.Nodes[0].Source != NodeSourceSubscription {
+		t.Fatalf("Source = %q, want %q", cfg.Nodes[0].Source, NodeSourceSubscription)
+	}
+	if cfg.Nodes[0].PoolEnabled == nil || *cfg.Nodes[0].PoolEnabled {
+		t.Fatalf("PoolEnabled = %v, want false", cfg.Nodes[0].PoolEnabled)
+	}
+}
+
+func TestSaveNodePrefs_PrunesRemovedNodes(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: pool\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	currentURI := "socks5://127.0.0.1:1080#Current"
+	cfg := &Config{
+		Mode: "pool",
+		Nodes: []NodeConfig{
+			{URI: currentURI, PoolEnabled: testBoolPtr(false), Source: NodeSourceSubscription},
+		},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	if err := os.WriteFile(filepath.Join(dir, nodePrefsFile), []byte(`{"stale":{"pool_enabled":false}}`), 0o644); err != nil {
+		t.Fatalf("write stale prefs: %v", err)
+	}
+	if err := cfg.SaveNodePrefs(); err != nil {
+		t.Fatalf("SaveNodePrefs: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(dir, nodePrefsFile))
+	if err != nil {
+		t.Fatalf("read prefs: %v", err)
+	}
+	var prefs map[string]NodePrefs
+	if err := json.Unmarshal(data, &prefs); err != nil {
+		t.Fatalf("decode prefs: %v", err)
+	}
+	if _, ok := prefs["stale"]; ok {
+		t.Fatalf("stale preference was not pruned: %v", prefs)
+	}
+	if _, ok := prefs[stableNodeKey(currentURI)]; !ok {
+		t.Fatalf("current preference missing: %v", prefs)
+	}
+}
+
+func TestSaveNodes_PreservesInlinePoolEnabled(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: hybrid\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &Config{
+		Mode: "hybrid",
+		Nodes: []NodeConfig{
+			{
+				Name:        "Premium",
+				URI:         "socks5://127.0.0.1:1080#Premium",
+				PoolEnabled: testBoolPtr(false),
+				Source:      NodeSourceInline,
+			},
+		},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	if err := cfg.SaveNodes(); err != nil {
+		t.Fatalf("SaveNodes: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	if !strings.Contains(string(data), "pool_enabled: false") {
+		t.Fatalf("expected pool_enabled to be persisted, got:\n%s", data)
+	}
+}
+
+func TestSaveSettings_PreservesPoolExcludeKeywords(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: pool\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg := &Config{
+		Mode: "pool",
+		Pool: PoolConfig{
+			Mode:            "sequential",
+			ExcludeKeywords: []string{"Premium", "HighRate"},
+		},
+	}
+	cfg.SetFilePath(cfgPath)
+
+	if err := cfg.SaveSettings(); err != nil {
+		t.Fatalf("SaveSettings: %v", err)
+	}
+
+	data, err := os.ReadFile(cfgPath)
+	if err != nil {
+		t.Fatalf("read config: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "exclude_keywords:") ||
+		!strings.Contains(content, "- Premium") ||
+		!strings.Contains(content, "- HighRate") {
+		t.Fatalf("expected exclude_keywords to be persisted, got:\n%s", content)
+	}
+}

--- a/internal/monitor/assets/index.html
+++ b/internal/monitor/assets/index.html
@@ -548,6 +548,7 @@
                   <th>地域</th>
                   <th>名称 (Name/Tag)</th>
                   <th>端口</th>
+                  <th>代理池</th>
                   <th>延迟 / 质量</th>
                   <th>连接</th>
                   <th>失败</th>
@@ -584,7 +585,7 @@
         <div class="panel">
           <div class="table-container">
             <table>
-              <thead><tr><th>名称</th><th>URI</th><th>端口</th><th>来源</th><th>操作</th></tr></thead>
+              <thead><tr><th>名称</th><th>URI</th><th>端口</th><th>代理池</th><th>来源</th><th>操作</th></tr></thead>
               <tbody id="configNodesTableBody"></tbody>
             </table>
           </div>
@@ -720,6 +721,10 @@
                 </div>
                 <div class="form-group"><label>故障阈值</label><input type="number" id="settingPoolFailure" class="setting-input" min="1" max="100" placeholder="3" /></div>
                 <div class="form-group"><label>黑名单时长</label><input type="text" id="settingPoolBlacklist" class="setting-input" placeholder="24h" /></div>
+                <div class="form-group" style="grid-column: 1 / -1;">
+                  <label>排除关键词（每行一个，匹配节点名称、Tag 或 URI）</label>
+                  <textarea id="settingPoolExcludeKeywords" class="setting-input" rows="3" placeholder="Premium&#10;高倍率&#10;倍率:5"></textarea>
+                </div>
               </div>
             </div>
 
@@ -861,6 +866,14 @@
           <div class="form-group">
             <label>映射端口 (可选)</label>
             <input type="number" id="nodePort" placeholder="0" />
+          </div>
+          <div class="form-group">
+            <label>代理池策略</label>
+            <select id="nodePoolEnabled" class="setting-input">
+              <option value="">默认（跟随关键词规则）</option>
+              <option value="true">加入代理池</option>
+              <option value="false">仅独立端口</option>
+            </select>
           </div>
           <input type="hidden" id="nodeEditName" />
         </div>
@@ -1253,6 +1266,7 @@
             <div class="cell-trunc" style="font-size: 11px; color: var(--text-muted)" title="${escapeHtml(n.tag)}">${escapeHtml(n.tag)}</div>
           </td>
           <td class="tt-mono">${n.port || '-'}</td>
+          <td><span class="badge ${n.pool_enabled ? 'badge-healthy' : 'badge-warning'}">${n.pool_enabled ? '入池' : '独立'}</span></td>
           <td>
             <div style="display:flex; align-items:center;">
               <span class="tt-mono" style="width:40px">${ms>=0 ? ms+'ms' : '-'}</span>
@@ -1400,6 +1414,7 @@
             <td><strong class="cell-trunc" style="display:inline-block;vertical-align:bottom" title="${escapeHtml(n.name)}">${escapeHtml(n.name)}</strong></td>
             <td class="tt-mono cell-trunc cell-trunc-uri" title="${escapeHtml(n.uri)}">${escapeHtml(n.uri)}</td>
             <td class="tt-mono">${n.port || '-'}</td>
+            <td><span class="badge ${nodePoolBadge(n).cls}">${nodePoolBadge(n).text}</span></td>
             <td><span class="badge ${n.source==='subscription'?'badge-warning':'badge-healthy'}">${n.source||'manual'}</span></td>
             <td>
               <button class="btn btn-sm" onclick="showEditNodeModal('${escapeAttrJs(n.name)}')">编辑</button>
@@ -1411,16 +1426,28 @@
       } catch(e){}
     }
 
-    function showAddNodeModal() { isEditMode=false; document.getElementById('nodeModalTitle').textContent='添加节点'; document.getElementById('nodeName').value=''; document.getElementById('nodeUri').value=''; document.getElementById('nodePort').value=''; document.getElementById('nodeModalOverlay').classList.add('show');}
+    function nodePoolBadge(n) {
+      if (n.pool_enabled === true) return { cls: 'badge-healthy', text: '入池' };
+      if (n.pool_enabled === false) return { cls: 'badge-warning', text: '独立' };
+      return { cls: 'badge-offline', text: '默认' };
+    }
+    function showAddNodeModal() { isEditMode=false; document.getElementById('nodeModalTitle').textContent='添加节点'; document.getElementById('nodeName').value=''; document.getElementById('nodeUri').value=''; document.getElementById('nodePort').value=''; document.getElementById('nodePoolEnabled').value=''; document.getElementById('nodeModalOverlay').classList.add('show');}
     function showEditNodeModal(name) { 
       const n = configNodes.find(x=>x.name===name); if(!n) return;
       isEditMode=true; document.getElementById('nodeModalTitle').textContent='编辑节点';
       document.getElementById('nodeName').value=n.name; document.getElementById('nodeUri').value=n.uri; document.getElementById('nodePort').value=n.port||''; document.getElementById('nodeEditName').value=n.name;
+      document.getElementById('nodePoolEnabled').value = n.pool_enabled === true ? 'true' : (n.pool_enabled === false ? 'false' : '');
       document.getElementById('nodeModalOverlay').classList.add('show');
     }
     async function handleNodeSubmit(e) {
       e.preventDefault();
-      const p = { name: document.getElementById('nodeName').value, uri: document.getElementById('nodeUri').value, port: parseInt(document.getElementById('nodePort').value)||0 };
+      const p = {
+        name: document.getElementById('nodeName').value,
+        uri: document.getElementById('nodeUri').value,
+        port: parseInt(document.getElementById('nodePort').value)||0
+      };
+      const poolValue = document.getElementById('nodePoolEnabled').value;
+      if (poolValue !== '') p.pool_enabled = poolValue === 'true';
       try {
         const editName = document.getElementById('nodeEditName').value;
         const url = isEditMode ? '/api/nodes/config/'+encodeURIComponent(editName) : '/api/nodes/config';
@@ -1554,6 +1581,7 @@
         document.getElementById('settingPoolMode').value = pl.mode || 'random';
         document.getElementById('settingPoolFailure').value = pl.failure_threshold || 3;
         document.getElementById('settingPoolBlacklist').value = pl.blacklist_duration || '24h';
+        document.getElementById('settingPoolExcludeKeywords').value = (pl.exclude_keywords || []).join('\n');
         // Sticky
         const st = d.sticky || {};
         document.getElementById('settingStickyEnabled').checked = !!st.enabled;
@@ -1612,6 +1640,7 @@
         pool_mode: document.getElementById('settingPoolMode').value,
         pool_failure: document.getElementById('settingPoolFailure').value,
         pool_blacklist: document.getElementById('settingPoolBlacklist').value,
+        pool_exclude_keywords: document.getElementById('settingPoolExcludeKeywords').value,
         sticky_enabled: document.getElementById('settingStickyEnabled').checked,
         sticky_port: document.getElementById('settingStickyPort').value,
         mgmt_listen: document.getElementById('settingMgmtListen').value,
@@ -1678,6 +1707,7 @@
             mode: document.getElementById('settingPoolMode').value,
             failure_threshold: parseInt(document.getElementById('settingPoolFailure').value) || 3,
             blacklist_duration: document.getElementById('settingPoolBlacklist').value || '24h',
+            exclude_keywords: document.getElementById('settingPoolExcludeKeywords').value.split('\n').map(s => s.trim()).filter(s => s),
           },
           sticky: {
             enabled: document.getElementById('settingStickyEnabled').checked,

--- a/internal/monitor/manager.go
+++ b/internal/monitor/manager.go
@@ -36,6 +36,7 @@ type NodeInfo struct {
 	Mode          string `json:"mode"`
 	ListenAddress string `json:"listen_address,omitempty"`
 	Port          uint16 `json:"port,omitempty"`
+	PoolEnabled   bool   `json:"pool_enabled"`
 	Region        string `json:"region,omitempty"`  // GeoIP region code: "jp", "kr", "us", "hk", "tw", "other"
 	Country       string `json:"country,omitempty"` // Full country name from GeoIP
 }

--- a/internal/monitor/server.go
+++ b/internal/monitor/server.go
@@ -926,6 +926,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 				"mode":               cfg.Pool.Mode,
 				"failure_threshold":  cfg.Pool.FailureThreshold,
 				"blacklist_duration": cfg.Pool.BlacklistDuration.String(),
+				"exclude_keywords":   cfg.Pool.ExcludeKeywords,
 			}
 			resp["sticky"] = map[string]any{
 				"enabled": cfg.Sticky.Enabled,
@@ -965,9 +966,10 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 				Password string `json:"password"`
 			} `json:"multi_port,omitempty"`
 			Pool *struct {
-				Mode              string `json:"mode"`
-				FailureThreshold  int    `json:"failure_threshold"`
-				BlacklistDuration string `json:"blacklist_duration"`
+				Mode              string   `json:"mode"`
+				FailureThreshold  int      `json:"failure_threshold"`
+				BlacklistDuration string   `json:"blacklist_duration"`
+				ExcludeKeywords   []string `json:"exclude_keywords"`
 			} `json:"pool,omitempty"`
 			Sticky *struct {
 				Enabled bool   `json:"enabled"`
@@ -1041,6 +1043,7 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 			if req.Pool != nil {
 				s.cfgSrc.Pool.Mode = req.Pool.Mode
 				s.cfgSrc.Pool.FailureThreshold = req.Pool.FailureThreshold
+				s.cfgSrc.Pool.ExcludeKeywords = cleanKeywords(req.Pool.ExcludeKeywords)
 				if req.Pool.BlacklistDuration != "" {
 					if d, err := time.ParseDuration(req.Pool.BlacklistDuration); err == nil {
 						s.cfgSrc.Pool.BlacklistDuration = d
@@ -1083,6 +1086,20 @@ func (s *Server) handleSettings(w http.ResponseWriter, r *http.Request) {
 	default:
 		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
+}
+
+func cleanKeywords(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	cleaned := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			cleaned = append(cleaned, value)
+		}
+	}
+	return cleaned
 }
 
 // handleSubscriptionStatus returns the current subscription refresh status.
@@ -1233,20 +1250,22 @@ func (s *Server) handleSubscriptionConfig(w http.ResponseWriter, r *http.Request
 
 // nodePayload is the JSON request body for node CRUD operations.
 type nodePayload struct {
-	Name     string `json:"name"`
-	URI      string `json:"uri"`
-	Port     uint16 `json:"port"`
-	Username string `json:"username"`
-	Password string `json:"password"`
+	Name        string `json:"name"`
+	URI         string `json:"uri"`
+	Port        uint16 `json:"port"`
+	Username    string `json:"username"`
+	Password    string `json:"password"`
+	PoolEnabled *bool  `json:"pool_enabled"`
 }
 
 func (p nodePayload) toConfig() config.NodeConfig {
 	return config.NodeConfig{
-		Name:     p.Name,
-		URI:      p.URI,
-		Port:     p.Port,
-		Username: p.Username,
-		Password: p.Password,
+		Name:        p.Name,
+		URI:         p.URI,
+		Port:        p.Port,
+		Username:    p.Username,
+		Password:    p.Password,
+		PoolEnabled: p.PoolEnabled,
 	}
 }
 

--- a/internal/outbound/pool/pool.go
+++ b/internal/outbound/pool/pool.go
@@ -61,6 +61,7 @@ type MemberMeta struct {
 	Mode          string
 	ListenAddress string
 	Port          uint16
+	PoolEnabled   bool
 	Region        string // GeoIP region code: "jp", "kr", "us", "hk", "tw", "other"
 	Country       string // Full country name from GeoIP
 }
@@ -142,6 +143,7 @@ func newPool(ctx context.Context, _ adapter.Router, logger singlog.ContextLogger
 				Mode:          meta.Mode,
 				ListenAddress: meta.ListenAddress,
 				Port:          meta.Port,
+				PoolEnabled:   meta.PoolEnabled,
 				Region:        meta.Region,
 				Country:       meta.Country,
 			}
@@ -247,6 +249,7 @@ func (p *poolOutbound) initializeMembersLocked() error {
 				Mode:          meta.Mode,
 				ListenAddress: meta.ListenAddress,
 				Port:          meta.Port,
+				PoolEnabled:   meta.PoolEnabled,
 				Region:        meta.Region,
 				Country:       meta.Country,
 			}

--- a/internal/subscription/manager.go
+++ b/internal/subscription/manager.go
@@ -597,6 +597,7 @@ func (m *Manager) createNewConfig(nodes []config.NodeConfig) *config.Config {
 	}
 
 	newCfg.Nodes = mergedNodes
+	newCfg.ApplyNodePrefs()
 	return &newCfg
 }
 

--- a/internal/subscription/manager_test.go
+++ b/internal/subscription/manager_test.go
@@ -1,6 +1,9 @@
 package subscription
 
 import (
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"easy_proxies/internal/config"
@@ -125,5 +128,39 @@ func TestCreateNewConfig_SubscriptionSourceMarked(t *testing.T) {
 	// Verify source is set to subscription
 	if newCfg.Nodes[0].Source != config.NodeSourceSubscription {
 		t.Errorf("expected source to be subscription, got %s", newCfg.Nodes[0].Source)
+	}
+}
+
+func TestCreateNewConfig_AppliesPersistedSubscriptionPoolPrefs(t *testing.T) {
+	dir := t.TempDir()
+	cfgPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(cfgPath, []byte("mode: hybrid\nnodes: []\n"), 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	oldURI := "vless://uuid-a@example.com:443?type=ws&security=tls#Old"
+	newURI := "vless://uuid-a@example.com:443?security=tls&type=ws#New"
+	poolEnabled := false
+	prefs := map[string]config.NodePrefs{
+		(&config.NodeConfig{URI: oldURI}).NodeKey(): {PoolEnabled: &poolEnabled},
+	}
+	data, err := json.Marshal(prefs)
+	if err != nil {
+		t.Fatalf("encode prefs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "node_prefs.json"), data, 0o644); err != nil {
+		t.Fatalf("write prefs: %v", err)
+	}
+
+	baseCfg := &config.Config{Mode: "hybrid"}
+	baseCfg.SetFilePath(cfgPath)
+	mgr := &Manager{baseCfg: baseCfg}
+
+	newCfg := mgr.createNewConfig([]config.NodeConfig{{Name: "New", URI: newURI}})
+	if len(newCfg.Nodes) != 1 {
+		t.Fatalf("nodes = %d, want 1", len(newCfg.Nodes))
+	}
+	if newCfg.Nodes[0].PoolEnabled == nil || *newCfg.Nodes[0].PoolEnabled {
+		t.Fatalf("PoolEnabled = %v, want false", newCfg.Nodes[0].PoolEnabled)
 	}
 }


### PR DESCRIPTION
## 摘要
- 新增节点级 `pool_enabled` 和 `pool.exclude_keywords`，用于控制节点是否加入共享代理池。
- 在 `hybrid` 模式下，被排除的节点仍然保留独立 multi-port 入口，但不会进入共享代理池。
- Sticky pool 和 GeoIP region pool 也使用同一套入池过滤逻辑。
- 订阅 / `nodes_file` 节点的入池偏好会保存到 `node_prefs.json`，并在 WebUI/API 中支持查看和编辑。

Closes #30

## 测试
- `git diff --check origin/main..HEAD`
- 实际验证：添加订阅和单个节点，将其中部分节点设置为“不入池”，随后更新订阅；单个节点和被设置过的订阅节点都没有恢复成默认入池状态，入池偏好保持正确。