### PR TITLE
fix(geoip): select regions from proxy request headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,95 +167,43 @@ Key behaviors:
 
 ### How to Use
 
-The GeoIP router is an HTTP proxy that listens on its own port. You select a region by adding a path prefix to your request.
-
-#### HTTP Requests
-
-Format: `http://<geoip_host>:<geoip_port>/<region>/`
-
-```bash
-# Route through Japanese nodes
-curl -x http://user:pass@localhost:1221/jp/ http://example.com
-
-# Route through US nodes
-curl -x http://user:pass@localhost:1221/us/ http://example.com
-
-# Route through Hong Kong nodes
-curl -x http://user:pass@localhost:1221/hk/ http://example.com
-
-# Route through Singapore nodes
-curl -x http://user:pass@localhost:1221/sg/ http://example.com
-
-# No region prefix = use global pool (all nodes)
-curl -x http://user:pass@localhost:1221/ http://example.com
-```
-
-#### HTTPS Requests (CONNECT Tunnel)
-
-For HTTPS, the region prefix goes before the target host in the CONNECT request:
+The GeoIP router is an HTTP proxy that listens on its own port. Select a
+region with the `X-Easyproxy-Region` proxy request header. This works for
+both regular HTTP requests and HTTPS CONNECT tunnels without changing the
+target URL.
 
 ```bash
-# Route HTTPS through Japanese nodes
-https_proxy=http://user:pass@localhost:1221/jp/ curl https://www.google.com
+# Route through Japanese nodes.
+curl --proxy http://user:pass@localhost:1221 \
+  --proxy-header 'X-Easyproxy-Region: jp' \
+  https://www.google.com
 
-# Route HTTPS through US nodes
-https_proxy=http://user:pass@localhost:1221/us/ curl https://www.google.com
+# Route through US nodes.
+curl --proxy http://user:pass@localhost:1221 \
+  --proxy-header 'X-Easyproxy-Region: us' \
+  http://example.com
 
-# No region prefix = use global pool
-https_proxy=http://user:pass@localhost:1221/ curl https://www.google.com
+# No header uses the global pool.
+curl --proxy http://user:pass@localhost:1221 https://www.google.com
 ```
 
-#### Using with Applications
+Supported values are `jp`, `kr`, `us`, `hk`, `tw`, `sg`, and `other`.
+Unsupported values return `400 Bad Request`. The header is removed before a
+regular HTTP request is forwarded to the target server.
 
-**Environment variables:**
+#### Legacy Path Fallback
 
-```bash
-# Use Japanese nodes for all traffic
-export http_proxy=http://user:pass@your-server:1221/jp/
-export https_proxy=http://user:pass@your-server:1221/jp/
-
-# Use global pool (all nodes)
-export http_proxy=http://user:pass@your-server:1221/
-export https_proxy=http://user:pass@your-server:1221/
-```
-
-**Browser proxy extensions (SwitchyOmega, FoxyProxy, etc.):**
-
-- Protocol: HTTP
-- Server: your-server-ip
-- Port: 1221
-- Username/Password: as configured in `listener`
-- For region-specific routing: set the proxy URL path to include the region prefix (e.g., `/jp/`)
-
-**Python requests:**
-
-```python
-import requests
-
-proxies = {
-    "http": "http://user:pass@your-server:1221/jp/",
-    "https": "http://user:pass@your-server:1221/jp/",
-}
-r = requests.get("http://example.com", proxies=proxies)
-```
-
-**Go net/http:**
-
-```go
-proxyURL, _ := url.Parse("http://user:pass@your-server:1221/jp/")
-client := &http.Client{
-    Transport: &http.Transport{
-        Proxy: http.ProxyURL(proxyURL),
-    },
-}
-resp, err := client.Get("http://example.com")
-```
+Path-based region selection remains available for clients that actually send
+the path in the proxy request, including `CONNECT jp/example.com:443`.
+Standard HTTP proxy clients do not transmit a path included in the proxy URL,
+so a proxy URL such as `http://localhost:1221/jp/` cannot select a region.
+Use a proxy-specific header facility instead.
 
 ### How It Works
 
 1. On startup, each node's server IP is resolved and looked up in the MaxMind GeoLite2-Country database
 2. Nodes are grouped into per-region pools (`pool-jp`, `pool-kr`, `pool-us`, etc.) with independent health checking
-3. The GeoIP router listens on its own port and inspects the request path for a region prefix
+3. The GeoIP router listens on its own port and selects a region from a proxy request header
 4. Matching requests are routed through the corresponding region pool; unmatched requests use the global pool
 5. Each region pool uses the same scheduling algorithm configured in the `pool` section
 6. DNS lookup results are cached to avoid repeated resolution on reload

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -88,6 +88,74 @@ dns:
 nodes_file: nodes.txt
 ```
 
+## GeoIP 地区路由
+
+启用 GeoIP 后，Easy Proxies 会按节点的地理位置自动分类，并提供独立
+HTTP 代理入口，以便通过指定地区的节点转发流量。
+
+### 支持的地区
+
+| 代码 | 地区 |
+| --- | --- |
+| `jp` | 日本 |
+| `kr` | 韩国 |
+| `us` | 美国 |
+| `hk` | 香港 |
+| `tw` | 台湾 |
+| `sg` | 新加坡 |
+| `other` | 其他地区 |
+
+### 配置
+
+```yaml
+geoip:
+  enabled: true
+  database_path: "./GeoLite2-Country.mmdb"
+  listen: "0.0.0.0"          # 省略时使用 listener.address
+  port: 1221                  # 省略时使用 listener.port
+  auto_update_enabled: true   # 自动更新 GeoIP 数据库
+  auto_update_interval: 24h   # 检查间隔
+```
+
+GeoIP 路由器复用 `listener.username` 和 `listener.password` 进行代理认证。
+
+- 首次启动时会自动下载 MaxMind GeoLite2-Country 数据库。
+- 默认每 24 小时检查更新，并热重载数据库，无需重启。
+- 启动和每次重载时都会自动重新分类节点。
+- 无法解析或查询 IP 归属地的节点会进入 `other` 分类。
+
+### 使用方法
+
+GeoIP 路由器是独立端口上的 HTTP 代理。使用代理专用请求头
+`X-Easyproxy-Region` 选择地区；普通 HTTP 请求和 HTTPS `CONNECT`
+隧道都支持，且无需修改目标 URL。
+
+```bash
+# 通过日本节点访问 HTTPS 目标。
+curl --proxy http://user:pass@localhost:1221 \
+  --proxy-header 'X-Easyproxy-Region: jp' \
+  https://www.google.com
+
+# 通过美国节点访问 HTTP 目标。
+curl --proxy http://user:pass@localhost:1221 \
+  --proxy-header 'X-Easyproxy-Region: us' \
+  http://example.com
+
+# 不设置请求头时使用全局节点池。
+curl --proxy http://user:pass@localhost:1221 https://www.google.com
+```
+
+支持的值为 `jp`、`kr`、`us`、`hk`、`tw`、`sg` 和 `other`。不支持的值会
+返回 `400 Bad Request`。转发普通 HTTP 请求前会删除该内部请求头，不会将它
+发送给目标服务器。
+
+#### 旧路径格式兼容
+
+仍保留实际代理请求中携带路径时的地区选择，以及
+`CONNECT jp/example.com:443` 的旧格式兼容。标准 HTTP 代理客户端通常不会
+把代理地址中的路径发送给代理服务，因此 `http://localhost:1221/jp/`
+不能可靠地选择地区，应改用代理专用请求头功能。
+
 ## 粘性代理（可选，仅 Pool/Hybrid 模式）
 
 开启后会额外监听一个独立端口（默认 `listener.port + 1`，即 `2324`），与原 `2323` 端口共存。通过粘性端口接入的客户端会按**来源 IP** 固定绑定到同一个上游节点，保持出口 IP 稳定（避免轮询导致 IP 频繁跳变触发风控/掉登录态）。绑定为永久保持，仅当该节点被拉黑/移除时才重新选择。监听地址与认证复用 `listener` 配置。

--- a/internal/geoip/router.go
+++ b/internal/geoip/router.go
@@ -13,6 +13,8 @@ import (
 	"time"
 )
 
+const regionHeader = "X-Easyproxy-Region"
+
 // RouterConfig holds configuration for the GeoIP router
 type RouterConfig struct {
 	Listen   string
@@ -136,8 +138,12 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	// Extract region from path
-	region, targetHost := r.parseRequest(req)
+	// Extract the requested region after proxy authentication succeeds.
+	region, targetHost, err := r.parseRequest(req)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
 
 	// Get the appropriate pool
 	r.mu.RLock()
@@ -163,40 +169,57 @@ func (r *Router) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 }
 
 // parseRequest extracts region and target host from the request
-func (r *Router) parseRequest(req *http.Request) (region, targetHost string) {
-	// For CONNECT requests, the host is in req.Host
-	// For regular requests, check the path prefix
+func (r *Router) parseRequest(req *http.Request) (region, targetHost string, err error) {
+	// A proxy-specific header works for both regular HTTP requests and CONNECT
+	// tunnels. Remove it before forwarding a regular HTTP request upstream.
+	headerRegion := strings.TrimSpace(req.Header.Get(regionHeader))
+	req.Header.Del(regionHeader)
+	if headerRegion != "" {
+		region = strings.ToLower(headerRegion)
+		for _, reg := range AllRegions() {
+			if region == reg {
+				return region, req.Host, nil
+			}
+		}
+		return "", "", fmt.Errorf("unsupported GeoIP region %q", headerRegion)
+	}
 
+	// Retain the existing path and CONNECT authority forms as fallbacks.
 	if req.Method == http.MethodConnect {
 		// CONNECT requests: check if host starts with region prefix
 		// e.g., CONNECT jp/example.com:443 or just example.com:443
 		host := req.Host
+		// net/http parses jp/example.com:443 as URL.Host=jp and
+		// URL.Path=/example.com:443. Rebuild the original authority.
+		if req.URL != nil && req.URL.Host != "" && req.URL.Path != "" {
+			host = req.URL.Host + req.URL.Path
+		}
 		for _, reg := range AllRegions() {
 			prefix := reg + "/"
 			if strings.HasPrefix(host, prefix) {
-				return reg, strings.TrimPrefix(host, prefix)
+				return reg, strings.TrimPrefix(host, prefix), nil
 			}
 		}
-		return "", host
+		return "", host, nil
 	}
 
-	// For regular HTTP requests, check URL path
+	// For regular HTTP requests, check URL path.
 	path := req.URL.Path
 	for _, reg := range AllRegions() {
 		prefix := "/" + reg + "/"
 		if strings.HasPrefix(path, prefix) {
 			// Rewrite the path
 			req.URL.Path = "/" + strings.TrimPrefix(path, prefix)
-			return reg, req.Host
+			return reg, req.Host, nil
 		}
 		// Also check for exact match like /jp
 		if path == "/"+reg {
 			req.URL.Path = "/"
-			return reg, req.Host
+			return reg, req.Host, nil
 		}
 	}
 
-	return "", req.Host
+	return "", req.Host, nil
 }
 
 // handleConnect handles HTTPS CONNECT tunneling

--- a/internal/geoip/router_test.go
+++ b/internal/geoip/router_test.go
@@ -1,0 +1,64 @@
+package geoip
+
+import (
+	"bufio"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestParseRequestUsesRegionHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodGet, "http://example.com/jp/path", nil)
+	req.Header.Set(regionHeader, "US")
+
+	region, target, err := (&Router{}).parseRequest(req)
+	if err != nil {
+		t.Fatalf("parseRequest() error = %v", err)
+	}
+	if region != RegionUS {
+		t.Fatalf("region = %q, want %q", region, RegionUS)
+	}
+	if target != "example.com" {
+		t.Fatalf("target = %q, want %q", target, "example.com")
+	}
+	if got := req.URL.Path; got != "/jp/path" {
+		t.Fatalf("path = %q, want header selection to preserve it", got)
+	}
+	if got := req.Header.Get(regionHeader); got != "" {
+		t.Fatalf("region header was not removed: %q", got)
+	}
+}
+
+func TestParseRequestRejectsInvalidRegionHeader(t *testing.T) {
+	req := httptest.NewRequest(http.MethodConnect, "http://example.com:443", nil)
+	req.Header.Set(regionHeader, "invalid")
+
+	_, _, err := (&Router{}).parseRequest(req)
+	if err == nil {
+		t.Fatal("parseRequest() error = nil, want invalid region rejection")
+	}
+	if got := req.Header.Get(regionHeader); got != "" {
+		t.Fatalf("region header was not removed: %q", got)
+	}
+}
+
+func TestParseRequestFallsBackToRegionalConnectAuthority(t *testing.T) {
+	req, err := http.ReadRequest(bufio.NewReader(strings.NewReader(
+		"CONNECT jp/example.com:443 HTTP/1.1\r\nHost: example.com:443\r\n\r\n",
+	)))
+	if err != nil {
+		t.Fatalf("ReadRequest() error = %v", err)
+	}
+
+	region, target, err := (&Router{}).parseRequest(req)
+	if err != nil {
+		t.Fatalf("parseRequest() error = %v", err)
+	}
+	if region != RegionJP {
+		t.Fatalf("region = %q, want %q", region, RegionJP)
+	}
+	if target != "example.com:443" {
+		t.Fatalf("target = %q, want %q", target, "example.com:443")
+	}
+}


### PR DESCRIPTION
## 问题

当前 GeoIP 路由依赖代理请求路径选择地区，例如 `/jp/`。

但标准 HTTP 代理客户端通常不会把代理地址中配置的路径发送给代理服务。使用 `http://proxy:1221/jp/` 作为代理地址时，实际请求无法可靠携带 `/jp`；对于 HTTPS，客户端发送的是 `CONNECT target:443`，路径方式同样无法稳定工作。

因此，客户端仅修改代理地址、而不修改目标 URL 时，无法可靠选择地区出口。

## 解决方案

使用代理专用请求头 `X-Easyproxy-Region` 选择地区：

- 支持普通 HTTP 代理请求和 HTTPS `CONNECT` 隧道。
- 支持 `jp`、`kr`、`us`、`hk`、`tw`、`sg`、`other`。
- 请求头优先于旧的路径格式。
- 普通 HTTP 请求转发到目标服务器前会删除该内部请求头。
- 保留旧的 HTTP 路径及 `CONNECT jp/example.com:443` 兼容回退。
- 修复 `net/http` 将旧 CONNECT authority 拆分为 `URL.Host` 与 `URL.Path` 时的解析。

## 验证

新增 GeoIP 路由单元测试，覆盖：

- 请求头优先级及大小写处理。
- 不支持地区返回 `400 Bad Request`。
- 普通 HTTP 转发前移除内部请求头。
- 旧 `CONNECT jp/example.com:443` 兼容解析。

已执行：

```bash
go test ./internal/geoip